### PR TITLE
Better error messages: furthest

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -143,32 +143,32 @@ Parsimmon.Parser = P(function(_, _super, Parser) {
     return Parser(function(stream, i, onSuccess, onFailure) {
       var xs = [];
       var result = true;
-      var expected;
+      var furthestFailureI, furthestExpected;
 
       for (var times = 0; times < min; times += 1) {
-        result = self._(stream, i, success, firstFailure);
-        if (!result) return onFailure(stream, i, expected);
+        result = self._(stream, i, success, failure);
+        if (!result) return onFailure(stream, furthestFailureI, furthestExpected);
       }
 
       for (; times < max && result; times += 1) {
-        result = self._(stream, i, success, secondFailure);
+        result = self._(stream, i, success, failure);
       }
 
-      return onSuccess(stream, i, xs);
+      return onSuccess(stream, i, xs, furthestFailureI, furthestExpected);
 
-      function success(stream, newI, x) {
+      function success(stream, newI, x, successFurthestFailureI, successFurthestExpected) {
         i = newI;
         xs.push(x);
+        furthestFailureI = successFurthestFailureI;
+        furthestExpected = successFurthestExpected;
         return true;
       }
 
-      function firstFailure(stream, newI, msg) {
-        i = newI;
-        expected = msg;
-        return false;
-      }
-
-      function secondFailure(stream, newI, msg) {
+      function failure(stream, newI, expected) {
+        if (!(furthestFailureI > newI)) {
+          furthestFailureI = newI;
+          furthestExpected = expected;
+        }
         return false;
       }
     });

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -295,5 +295,17 @@ suite('parser', function() {
           partialEquals("Parse Error: expected 'def' at character 5, got '...de'\n    parsing: 'aaabcde'"));
       });
     });
+
+    suite('times', function() {
+      test('prefer longest branch in .times() too', function() {
+        var parser = string('abc').then(string('def')).or(string('a')).times(3, 6);
+
+        assert.throws(function() { parser.parse('aabcde'); },
+          partialEquals("Parse Error: expected 'def' at character 4, got '...de'\n    parsing: 'aabcde'"));
+
+        assert.throws(function() { parser.parse('aaaaabcde'); },
+            partialEquals("Parse Error: expected 'def' at character 7, got '...de'\n    parsing: 'aaaaabcde'"));
+      });
+    });
   });
 });


### PR DESCRIPTION
If a parser fails, always use the error message from the branch that advanced the furthest into the stream.

Ignore the first 5 commits, those are just #2.

Check out the nice error messages this gives for a toy "real world" example, an s-expression parser:

``` js
var atom = regex(/^[^()\s]+/);
var sexpr = string('(').then(function() { return list; }).skip(string(')'));
var list = optWhitespace.then(atom.or(sexpr)).skip(optWhitespace).many();

assert.deepEqual(list.parse('(a b) (c ((() d)))'), [['a', 'b'], ['c', [[[], 'd']]]]);

assert.throws(function() { list.parse('(a b ()) c)'); },
  partialEquals("Parse Error: expected EOF at character 10, got '...)'\n    parsing: '(a b ()) c)'"));
assert.throws(function() { list.parse('(a (b)) (() c'); },
  partialEquals("Parse Error: expected ')', got the end of the string\n    parsing: '(a (b)) (() c'"));
```

Before, the `.many().skip(eof)` would result in `expected EOF at character 0` for both.

I'm not ecstatic about how the code turned out; though the HOFs definitely cleaned up what I started with, it still feels like there's some duplication between `.or()`, `.then()`, and `.many()` in having to call `furthestFailure{,Success}` at all, almost like there should be some kind of HOF on the combinators that would just handle that stuff for you (note that what `.many()` does is basically equivalent to inlining `furthestFailure()`.

It's not too bad since it's restricted to the primitive or optimized combinators; honestly the most annoying thing is writing good, easy-to-understand minimal test cases of the edge cases where the wrong error message gets thrown, which is why I haven't finished `.times()`, wanna take a stab at it?
