### PR TITLE
Feature.index

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -208,6 +208,18 @@ Parsimmon.Parser = P(function(_, _super, Parser) {
     return this.then(function(result) { return two.result(result); });
   };
 
+  // TODO: this would be better implemented with `seq`
+  _.mark = function() {
+    var self = this;
+    return index.then(function(start) {
+      return self.then(function(value) {
+        return index.map(function(end) {
+          return { start: start, value: value, end: end };
+        });
+      });
+    });
+  };
+
   // -*- primitive parsers -*- //
   var string = Parsimmon.string = function(str) {
     var len = str.length;

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -243,6 +243,13 @@ suite('parser', function() {
     assert.equal(parser.parse('xxxx'), 4);
   });
 
+  test('mark', function() {
+    var ys = regex(/^y*/).mark()
+    var parser = optWhitespace.then(ys).skip(optWhitespace);
+    assert.deepEqual(parser.parse(''), { start: 0, value: '', end: 0 });
+    assert.deepEqual(parser.parse(' yy '), { start: 1, value: 'yy', end: 3 });
+  });
+
   suite('smart error messages', function() {
     // this is mainly about .or(), .many(), and .times(), but not about
     // their core functionality, so it's in its own test suite


### PR DESCRIPTION
This PR implements `Parsimmon.index` and `::mark()`, which allow the parser implementer access to index information during the parse.  This is useful if you want syntax nodes to reference source locations.
