### PR TITLE
Accept varargs in Parsimmon.seq()

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ a `'b'`, and fail otherwise.
     to match the given regex.
   - `Parsimmon.succeed(result)` is a parser that doesn't consume any of
     the string, and yields `result`.
-  - `Parsimmon.seq(parsers)` accepts an array of parsers that it expects to find in order,
-    yielding an array of the results.
+  - `Parsimmon.seq(p1, p2, ... pn)` accepts a variable number of parsers 
+    that it expects to find in order, yielding an array of the results.
   - `Parsimmon.lazy(f)` accepts a function that returns a parser, which is evaluated the
     first time the parser is used.  This is useful for referencing parsers that haven't yet
     been defined.

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -183,7 +183,7 @@ Parsimmon.Parser = P(function(_, _super, Parser) {
   _.atMost = function(n) { return this.times(0, n); };
   _.atLeast = function(n) {
     var self = this;
-    return seq([this.times(n), this.many()]).map(function(results) {
+    return seq(this.times(n), this.many()).map(function(results) {
       return results[0].concat(results[1]);
     });
   };
@@ -198,11 +198,11 @@ Parsimmon.Parser = P(function(_, _super, Parser) {
   };
 
   _.skip = function(next) {
-    return seq([this, next]).map(function(results) { return results[0]; });
+    return seq(this, next).map(function(results) { return results[0]; });
   };
 
   _.mark = function() {
-    return seq([index, this, index]).map(function(results) {
+    return seq(index, this, index).map(function(results) {
       return { start: results[0], value: results[1], end: results[2] };
     });
   };
@@ -284,6 +284,10 @@ Parsimmon.Parser = P(function(_, _super, Parser) {
 
   // [Parser a] -> Parser [a]
   var seq = Parsimmon.seq = function(parsers) {
+    if (parsers.length === undefined) {
+      parsers = arguments;
+    }
+
     return Parser(function(stream, i) {
       var result;
       var accum = new Array(parsers.length);
@@ -324,7 +328,7 @@ Parsimmon.Parser = P(function(_, _super, Parser) {
   _.of = Parser.of = Parsimmon.of = succeed
 
   _.ap = function(other) {
-    return seq([this, other]).map(function(results) {
+    return seq(this, other).map(function(results) {
       return results[0](results[1]);
     });
   };


### PR DESCRIPTION
The common case for seq is to pass a fixed number of parsers, so using
varargs rather than an explicit array is syntactically cleaner (as
well as less surprising IMHO).  I've kept the previous
array-as-first-arg behavior for backwards compatability.
Alternatively, that could be removed and anyone wishing to pass a
variable number of args can do:

seq.apply(null, [args])
