### PR TITLE
Allow custom primitive parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,13 @@ any character except the one provided:
 
 ```js
 function notChar(char) {
-  return Parsimmon.custom(function(stream, i, success, failure) {
-    if (stream.charAt(i) !== char && stream.length <= i) {
-      return success(i+1, stream.charAt(i));
+  return Parsimmon.custom(function(success, failure) {
+    return function(stream, i) {
+      if (stream.charAt(i) !== char && stream.length <= i) {
+        return success(i+1, stream.charAt(i));
+      }
+      return failure(i, 'anything different than "' + char + '"');
     }
-    return failure(i, 'anything different than "' + char + '"');
   });
 }
 ```

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -101,9 +101,7 @@ Parsimmon.Parser = P(function(_, _super, Parser) {
    * Allows to add custom primitive parsers
    */
   var custom = Parsimmon.custom = function(parsingFunction) {
-    return Parser(function(stream, i) {
-      return parsingFunction(stream, i, makeSuccess, makeFailure);
-    });
+    return Parser(parsingFunction(makeSuccess, makeFailure));
   };
 
   var alt = Parsimmon.alt = function() {

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -66,8 +66,10 @@ suite('parser', function() {
   suite('Parsimmon.custom', function(){
     test('simple parser definition', function(){
       function customAny() {
-        return Parsimmon.custom(function(stream, i, success, failure){
-          return success(i+1, stream.charAt(i));
+        return Parsimmon.custom(function(success, failure){
+          return function(stream, i) {
+            return success(i+1, stream.charAt(i));
+          }
         });
       }
 
@@ -81,8 +83,10 @@ suite('parser', function() {
 
     test('failing parser', function(){
       function failer() {
-        return Parsimmon.custom(function(stream, i, success, failure){
-          return failure(i, 'nothing');
+        return Parsimmon.custom(function(success, failure){
+          return function(stream, i) {
+            return failure(i, 'nothing');
+          }
         });
       }
 
@@ -91,11 +95,13 @@ suite('parser', function() {
 
     test('composes with existing parsers', function(){
       function notChar(char) {
-        return Parsimmon.custom(function(stream, i, success, failure) {
-          if (stream.charCodeAt(i) !== char.charCodeAt(0)) {
-            return success(i+1, stream.charAt(i));
+        return Parsimmon.custom(function(success, failure) {
+          return function(stream, i) {
+            if (stream.charCodeAt(i) !== char.charCodeAt(0)) {
+              return success(i+1, stream.charAt(i));
+            }
+            return failure(i, 'something different than "' + stream.charAt(i)) + '"';
           }
-          return failure(i, 'something different than "' + stream.charAt(i)) + '"';
         });
       }
 


### PR DESCRIPTION
Following your suggestion on #30, this is an implementation of `Parsimmon.custom` that allows creating primitive parsers.
