### PR TITLE
Allow failures to aggregate messages at equal indices

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -22,7 +22,7 @@ Parsimmon.Parser = (function() {
       index: index,
       value: value,
       furthest: -1,
-      expected: ''
+      expected: []
     };
   }
 
@@ -32,20 +32,24 @@ Parsimmon.Parser = (function() {
       index: -1,
       value: null,
       furthest: index,
-      expected: expected
+      expected: [expected]
     };
   }
 
-  function furthestBacktrackFor(result, last) {
+  function mergeReplies(result, last) {
     if (!last) return result;
-    if (result.furthest >= last.furthest) return result;
+    if (result.furthest > last.furthest) return result;
+
+    var expected = (result.furthest === last.furthest)
+      ? result.expected.concat(last.expected)
+      : last.expected;
 
     return {
       status: result.status,
       index: result.index,
       value: result.value,
       furthest: last.furthest,
-      expected: last.expected
+      expected: expected
     }
   }
 
@@ -53,20 +57,26 @@ Parsimmon.Parser = (function() {
     if (!(p instanceof Parser)) throw new Error('not a parser: '+p);
   }
 
-  var formatError = Parsimmon.formatError = function(stream, error) {
-    var expected = error.expected;
+  function formatExpected(expected) {
+    if (expected.length === 1) return expected[0];
+
+    'one of ' + expected.join(', ')
+  }
+
+  function formatGot(stream, error) {
     var i = error.index;
 
-    if (i === stream.length) {
-      return 'expected ' + expected + ', got the end of the string';
-    }
+    if (i === stream.length) return ', got the end of the stream'
+
 
     var prefix = (i > 0 ? "'..." : "'");
     var suffix = (stream.length - i > 12 ? "...'" : "'");
-    return (
-      'expected ' + expected + ' at character ' + i + ', got ' +
-      prefix + stream.slice(i, i+12) + suffix
-    );
+
+    return ' at character ' + i + ', got ' + prefix + stream.slice(i, i+12) + suffix
+  }
+
+  var formatError = Parsimmon.formatError = function(stream, error) {
+    return 'expected ' + formatExpected(error.expected) + formatGot(stream, error)
   };
 
   _.parse = function(stream) {
@@ -92,13 +102,13 @@ Parsimmon.Parser = (function() {
       var accum = new Array(numParsers);
 
       for (var j = 0; j < numParsers; j += 1) {
-        result = furthestBacktrackFor(parsers[j]._(stream, i), result);
+        result = mergeReplies(parsers[j]._(stream, i), result);
         if (!result.status) return result;
         accum[j] = result.value
         i = result.index;
       }
 
-      return furthestBacktrackFor(makeSuccess(i, accum), result);
+      return mergeReplies(makeSuccess(i, accum), result);
     });
   };
 
@@ -126,7 +136,7 @@ Parsimmon.Parser = (function() {
     return Parser(function(stream, i) {
       var result;
       for (var j = 0; j < parsers.length; j += 1) {
-        result = furthestBacktrackFor(parsers[j]._(stream, i), result);
+        result = mergeReplies(parsers[j]._(stream, i), result);
         if (result.status) return result;
       }
       return result;
@@ -170,14 +180,14 @@ Parsimmon.Parser = (function() {
       var prevResult;
 
       for (;;) {
-        result = furthestBacktrackFor(self._(stream, i), result);
+        result = mergeReplies(self._(stream, i), result);
 
         if (result.status) {
           i = result.index;
           accum.push(result.value);
         }
         else {
-          return furthestBacktrackFor(makeSuccess(i, accum), result);
+          return mergeReplies(makeSuccess(i, accum), result);
         }
       }
     });
@@ -215,7 +225,7 @@ Parsimmon.Parser = (function() {
 
       for (var times = 0; times < min; times += 1) {
         result = self._(stream, i);
-        prevResult = furthestBacktrackFor(result, prevResult);
+        prevResult = mergeReplies(result, prevResult);
         if (result.status) {
           i = result.index;
           accum.push(result.value);
@@ -225,7 +235,7 @@ Parsimmon.Parser = (function() {
 
       for (; times < max; times += 1) {
         result = self._(stream, i);
-        prevResult = furthestBacktrackFor(result, prevResult);
+        prevResult = mergeReplies(result, prevResult);
         if (result.status) {
           i = result.index;
           accum.push(result.value);
@@ -233,7 +243,7 @@ Parsimmon.Parser = (function() {
         else break;
       }
 
-      return furthestBacktrackFor(makeSuccess(i, accum), prevResult);
+      return mergeReplies(makeSuccess(i, accum), prevResult);
     });
   };
 
@@ -252,7 +262,7 @@ Parsimmon.Parser = (function() {
     return Parser(function(stream, i) {
       var result = self._(stream, i);
       if (!result.status) return result;
-      return furthestBacktrackFor(makeSuccess(result.index, fn(result.value)), result);
+      return mergeReplies(makeSuccess(result.index, fn(result.value)), result);
     });
   };
 
@@ -267,7 +277,12 @@ Parsimmon.Parser = (function() {
   };
 
   _.desc = function(expected) {
-    return this.or(fail(expected))
+    var self = this;
+    return Parser(function(stream, i) {
+      var reply = self._(stream, i);
+      if (!reply.status) reply.expected = [expected];
+      return reply;
+    });
   };
 
   // -*- primitive parsers -*- //
@@ -289,6 +304,7 @@ Parsimmon.Parser = (function() {
 
   var regex = Parsimmon.regex = function(re, group) {
     var anchored = RegExp('^(?:'+re.source+')', (''+re).slice((''+re).lastIndexOf('/')+1));
+    var expected = '' + re;
     if (group == null) group = 0;
 
     return Parser(function(stream, i) {
@@ -300,7 +316,7 @@ Parsimmon.Parser = (function() {
         if (groupMatch != null) return makeSuccess(i+fullMatch.length, groupMatch);
       }
 
-      return makeFailure(i, re);
+      return makeFailure(i, expected);
     });
   };
 
@@ -405,7 +421,7 @@ Parsimmon.Parser = (function() {
       var result = self._(stream, i);
       if (!result.status) return result;
       var nextParser = f(result.value);
-      return furthestBacktrackFor(nextParser._(stream, result.index), result);
+      return mergeReplies(nextParser._(stream, result.index), result);
     });
   };
 

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -60,7 +60,7 @@ Parsimmon.Parser = (function() {
   function formatExpected(expected) {
     if (expected.length === 1) return expected[0];
 
-    'one of ' + expected.join(', ')
+    return 'one of ' + expected.join(', ')
   }
 
   function formatGot(stream, error) {

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -38,12 +38,12 @@ suite('parser', function() {
     assert.deepEqual(parser.parse('x0'), {
       status: false,
       index: 0,
-      expected: /[0-9]/
+      expected: ['/[0-9]/']
     });
     assert.deepEqual(parser.parse('0x'), {
       status: false,
       index: 1,
-      expected: 'EOF'
+      expected: ['EOF']
     });
   });
 
@@ -63,12 +63,12 @@ suite('parser', function() {
       assert.deepEqual(parser.parse('(string'), {
           status: false,
           index: 7,
-          expected: "')'"
+          expected: ["')'", "/[^\\)]/"]
       });
       assert.deepEqual(parser.parse('starts wrong (string between parens)'), {
           status: false,
           index: 0,
-          expected: "'('"
+          expected: ["'('"]
       });
   });
 
@@ -99,7 +99,7 @@ suite('parser', function() {
         });
       }
 
-      assert.deepEqual(failer().parse('a'), {status: false, index: 0, expected: 'nothing'})
+      assert.deepEqual(failer().parse('a'), {status: false, index: 0, expected: ['nothing']})
     });
 
     test('composes with existing parsers', function(){
@@ -152,12 +152,12 @@ suite('parser', function() {
       assert.deepEqual(parser.parse('xy'), { status: true, value: 'y' });
       assert.deepEqual(parser.parse('y'), {
         status: false,
-        expected: "'x'",
+        expected: ["'x'"],
         index: 0
       })
       assert.deepEqual(parser.parse('xz'), {
         status: false,
-        expected: "'y'",
+        expected: ["'y'"],
         index: 1
       });
     });
@@ -325,7 +325,7 @@ suite('parser', function() {
       assert.deepEqual(parser.parse('y'), {
         status: false,
         index: 1,
-        expected: 'a character besides y'
+        expected: ['a character besides y']
       });
       assert.equal(parser.parse('x').value, 'x');
     });
@@ -348,7 +348,7 @@ suite('parser', function() {
       assert.deepEqual(parser.parse('x*y'), {
         status: false,
         index: 2,
-        expected: '+'
+        expected: ['+']
       });
 
       allowedOperator = '*';
@@ -356,7 +356,7 @@ suite('parser', function() {
       assert.deepEqual(parser.parse('x+y'), {
         status: false,
         index: 2,
-        expected: '*'
+        expected: ['*']
       });
     });
   });
@@ -408,7 +408,7 @@ suite('parser', function() {
         assert.deepEqual(parser.parse('abc'), {
           status: false,
           index: 3,
-          expected: "'def'"
+          expected: ["'def'"]
         });
       });
 
@@ -418,7 +418,7 @@ suite('parser', function() {
         assert.deepEqual(parser.parse('abc'), {
           status: false,
           index: 3,
-          expected: "'d'"
+          expected: ["'d'", "'def'"]
         });
       });
 
@@ -429,7 +429,7 @@ suite('parser', function() {
         assert.deepEqual(parser.parse('abcdef'), {
           status: false,
           index: 6,
-          expected: "'g'"
+          expected: ["'g'"]
         });
       });
     });
@@ -439,7 +439,7 @@ suite('parser', function() {
         var list = lazy(function() {
           return optWhitespace.then(atom.or(sexpr)).skip(optWhitespace).many();
         });
-        var atom = regex(/^[^()\s]+/);
+        var atom = regex(/[^()\s]+/).desc('an atom');
         var sexpr = string('(').then(list).skip(string(')'));
 
         assert.deepEqual(list.parse('(a b) (c ((() d)))').value,
@@ -448,13 +448,13 @@ suite('parser', function() {
         assert.deepEqual(list.parse('(a b ()) c)'), {
           status: false,
           index: 10,
-          expected: 'EOF'
+          expected: ['EOF', "'('", "an atom"]
         });
 
         assert.deepEqual(list.parse('(a (b)) (() c'), {
           status: false,
           index: 13,
-          expected: "')'"
+          expected: ["')'", "'('", "an atom"]
         });
       });
 
@@ -467,7 +467,7 @@ suite('parser', function() {
         assert.deepEqual(parser.parse('aaabcde'), {
           status: false,
           index: 5,
-          expected: "'def'"
+          expected: ["'def'"]
         });
       });
     });
@@ -479,13 +479,13 @@ suite('parser', function() {
         assert.deepEqual(parser.parse('aabcde'), {
           status: false,
           index: 4,
-          expected: "'def'"
+          expected: ["'def'"]
         });
 
         assert.deepEqual(parser.parse('aaaaabcde'), {
           status: false,
           index: 7,
-          expected: "'def'"
+          expected: ["'def'"]
         });
       });
     });
@@ -499,13 +499,13 @@ suite('parser', function() {
         assert.deepEqual(parser.parse('a'), {
           status: false,
           index: 0,
-          expected: 'the letter x'
+          expected: ['the letter x']
         });
 
         assert.deepEqual(parser.parse('xa'), {
           status: false,
           index: 1,
-          expected: 'the letter y'
+          expected: ['the letter y']
         });
       });
 
@@ -517,13 +517,13 @@ suite('parser', function() {
         assert.deepEqual(parser.parse('a'), {
           status: false,
           index: 0,
-          expected: 'the letter x'
+          expected: ['the letter x']
         });
 
         assert.deepEqual(parser.parse('xa'), {
           status: false,
           index: 1,
-          expected: 'the letter y'
+          expected: ['the letter y']
         });
       });
     });


### PR DESCRIPTION
This approach is lifted wholesale from Parsec.  It turns out that it's
relatively common for several parsers to fail at the same index, which
indicates more than one possible way the user could fix the parse error.
This changes the .expected keys from strings to arrays of strings which
aggregate equal-index parse errors.  They can still be passed to
formatExpected(), so this should be non-breaking for anyone who was
simply passing the expected result in - but it will break for anyone who
was accessing the string directly.

/cc @laughinghan 