### PR TITLE
Adding sepBy and sepBy1

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ error string.
     that it expects to find in order, yielding an array of the results.
   - `Parsimmon.alt(p1, p2, ... pn)` accepts a variable number of parsers,
     and yields the value of the first one that succeeds, backtracking in between.
+  - `Parsimmon.sepBy(content, separator)` accepts two parsers, and expects multiple 
+    `content`s, separated by `separator`s. Yields an array of `contents`.  
+  - `Parsimmon.sepBy1(content, separator)` same as `Parsimmon.sepBy`, but expects
+    `content` to succeed at least once.
   - `Parsimmon.lazy(f)` accepts a function that returns a parser, which
     is evaluated the first time the parser is used.  This is useful for
     referencing parsers that haven't yet been defined.

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -143,6 +143,23 @@ Parsimmon.Parser = (function() {
     });
   };
 
+  var sepBy = Parsimmon.sepBy = function(parser, separator) {
+    return sepBy1(parser, separator).or(Parsimmon.of([]));
+  };
+
+  var sepBy1 = Parsimmon.sepBy1 = function(parser, separator) {
+    assertParser(parser);
+    assertParser(separator);
+
+    var pairs = separator.then(parser).many();
+
+    return parser.chain(function(r) {
+      return pairs.map(function(rs) {
+        return [r].concat(rs);
+      })
+    })
+  };
+
   // -*- primitive combinators -*- //
   _.or = function(alternative) {
     return alt(this, alternative);

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -144,7 +144,45 @@ suite('parser', function() {
          type: 'identifier',
          value: 'anIdentifier'
       });
-  })
+  });
+
+  suite('Parsimmon.sepBy/sepBy1', function() {
+    var chars   = regex(/[a-zA-Z]+/);
+    var comma   = string(',');
+    var csvSep  = Parsimmon.sepBy(chars, comma);
+    var csvSep1 = Parsimmon.sepBy1(chars, comma);
+
+
+    test('successful, returns an array of parsed elements', function(){
+      var input  = 'Heres,a,csv,string,in,our,restrictive,dialect';
+      var output = ['Heres', 'a', 'csv', 'string', 'in', 'our', 'restrictive', 'dialect']
+
+
+      assert.deepEqual(csvSep.parse(input).value, output);
+      assert.deepEqual(csvSep1.parse(input).value, output);
+    });
+
+    test('sepBy succeeds with the empty list on empty input, sepBy1 fails', function() {
+      assert.deepEqual(csvSep.parse('').value, []);
+      assert.deepEqual(csvSep1.parse(''), {
+        status: false,
+        index: 0,
+        expected: ['/[a-zA-Z]+/']
+      });
+    });
+
+    test('does not tolerate trailing separators', function() {
+      var input = 'Heres,a,csv,with,a,trailing,comma,';
+      var output = {
+        status: false,
+        index: 34,
+        expected: ['/[a-zA-Z]+/']
+      };
+
+      assert.deepEqual(csvSep.parse(input), output);
+      assert.deepEqual(csvSep1.parse(input), output);
+    });
+  });
 
   suite('then', function() {
     test('with a parser, uses the last return value', function() {


### PR DESCRIPTION
I've stolen the implementations pretty much wholesale from the haskell
implementation; so they may well not be optimal. :|

I've taken the liberty of bumping the version number and updating the changelog; feel free to tell me to roll that back if you'd prefer to release other features (assuming you're okay with adding this to the library). 

Addresses  #29