### PR TITLE
Create methods for marking line and column offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ error string.
   - `Parsimmon.all` consumes and yields the entire remainder of the stream.
   - `Parsimmon.eof` expects the end of the stream.
   - `Parsimmon.index` is a parser that yields the current index of the parse.
+  - `Parsimmon.indexLineColumn` is a parser that yields an object with a more
+    verbose index of the parse: it has 0-based `line` and `column` numbers as
+    well as the character `offset`.
   - `Parsimmon.test(pred)` yield a single character if it passes the predicate.
   - `Parsimmon.takeWhile(pred)` yield a string containing all the next characters that pass the predicate.
 
@@ -164,6 +167,11 @@ parser.parse('accccc');
   - `parser.mark()` yields an object with `start`, `value`, and `end` keys, where
     `value` is the original value yielded by the parser, and `start` and `end` are
     the indices in the stream that contain the parsed text.
+  - `parser.markLineColumn()` is a more verbose version of `mark`: it yields an
+    object with `start`, `value`, and `end` keys, where `value` is the original
+    value yielded by the parser, and `start` and `end` are objects with
+    `offset`, `line` and `column` properties that represent the position in the
+    stream that contained the parsed text.
   - `parser.desc(description)` returns a new parser whose failure message is the passed
     description.  For example, `string('x').desc('the letter x')` will indicate that
     'the letter x' was expected.

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ error string.
   - `Parsimmon.eof` expects the end of the stream.
   - `Parsimmon.index` is a parser that yields the current index of the parse.
   - `Parsimmon.indexLineColumn` is a parser that yields an object with a more
-    verbose index of the parse: it has 0-based `line` and `column` numbers as
-    well as the character `offset`.
+    verbose index of the parse: it has a 0-based character `offset` and 1-based
+    `line` and `column` numbers.
   - `Parsimmon.test(pred)` yield a single character if it passes the predicate.
   - `Parsimmon.takeWhile(pred)` yield a string containing all the next characters that pass the predicate.
 
@@ -169,9 +169,9 @@ parser.parse('accccc');
     the indices in the stream that contain the parsed text.
   - `parser.markLineColumn()` is a more verbose version of `mark`: it yields an
     object with `start`, `value`, and `end` keys, where `value` is the original
-    value yielded by the parser, and `start` and `end` are objects with
-    `offset`, `line` and `column` properties that represent the position in the
-    stream that contained the parsed text.
+    value yielded by the parser, and `start` and `end` are objects with a
+    0-based `offset` and 1-based `line` and `column` properties that represent
+    the position in the stream that contained the parsed text.
   - `parser.desc(description)` returns a new parser whose failure message is the passed
     description.  For example, `string('x').desc('the letter x')` will indicate that
     'the letter x' was expected.

--- a/README.md
+++ b/README.md
@@ -58,14 +58,13 @@ digits.map(function(x) { return parseInt(x) * 2; })
 will yield the number 24 when it encounters the string '12'.  The method
 `.result` can be used to set a constant result.
 
-Calling `.parse(str)` on a parser parses the string, and returns an
-object with a `status` flag, indicating whether the parse succeeded.
-If it succeeded, the `value` attribute will contain the yielded value.
-Otherwise, the `index` and `expected` attributes will contain the
-index of the parse error, and a message indicating what was expected.
+Calling `.parse(str)` on a parser parses the string, and returns an object with
+a `status` flag, indicating whether the parse succeeded.  If it succeeded, the
+`value` attribute will contain the yielded value.  Otherwise, the `index` and
+`expected` attributes will contain the index of the parse error (with `offset`,
+`line` and `column` properties), and a message indicating what was expected.
 The error object can be passed along with the original source to
-`Parsimmon.formatError(source, error)` to obtain a human-readable
-error string.
+`Parsimmon.formatError(source, error)` to obtain a human-readable error string.
 
 ## Full API
 
@@ -100,10 +99,9 @@ error string.
   - `Parsimmon.any` consumes and yields the next character of the stream.
   - `Parsimmon.all` consumes and yields the entire remainder of the stream.
   - `Parsimmon.eof` expects the end of the stream.
-  - `Parsimmon.index` is a parser that yields the current index of the parse.
-  - `Parsimmon.indexLineColumn` is a parser that yields an object with a more
-    verbose index of the parse: it has a 0-based character `offset` and 1-based
-    `line` and `column` numbers.
+  - `Parsimmon.index` is a parser that yields an object an object representing
+    the current offset into the parse: it has a 0-based character `offset`
+    property and 1-based `line` and `column` properties.
   - `Parsimmon.test(pred)` yield a single character if it passes the predicate.
   - `Parsimmon.takeWhile(pred)` yield a string containing all the next characters that pass the predicate.
 
@@ -164,14 +162,11 @@ parser.parse('accccc');
     expects `parser` at most `n` times.  Yields an array of the results.
   - `parser.atLeast(n)`:
     expects `parser` at least `n` times.  Yields an array of the results.
-  - `parser.mark()` yields an object with `start`, `value`, and `end` keys, where
-    `value` is the original value yielded by the parser, and `start` and `end` are
-    the indices in the stream that contain the parsed text.
-  - `parser.markLineColumn()` is a more verbose version of `mark`: it yields an
-    object with `start`, `value`, and `end` keys, where `value` is the original
-    value yielded by the parser, and `start` and `end` are objects with a
-    0-based `offset` and 1-based `line` and `column` properties that represent
-    the position in the stream that contained the parsed text.
+  - `parser.mark()` yields an object with `start`, `value`, and `end` keys,
+    where `value` is the original value yielded by the parser, and `start` and
+    `end` are are objects with a 0-based `offset` and 1-based `line` and
+    `column` properties that represent the position in the stream that
+    contained the parsed text.
   - `parser.desc(description)` returns a new parser whose failure message is the passed
     description.  For example, `string('x').desc('the letter x')` will indicate that
     'the letter x' was expected.

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -436,8 +436,9 @@ Parsimmon.Parser = (function() {
 
       var lines = stream.slice(0, i).split("\n");
 
-      var lineWeAreUpTo = lines.length - 1;
-      var columnWeAreUpTo = lines[lines.length - 1].length;
+      // Unlike the character offset, lines and columns are 1-based.
+      var lineWeAreUpTo = lines.length;
+      var columnWeAreUpTo = lines[lines.length - 1].length + 1;
 
       return makeSuccess(i, {
         offset: i,

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -64,7 +64,8 @@ Parsimmon.Parser = (function() {
   }
 
   function formatGot(stream, error) {
-    var i = error.index.offset;
+    var index = error.index;
+    var i = index.offset;
 
     if (i === stream.length) return ', got the end of the stream'
 
@@ -72,7 +73,8 @@ Parsimmon.Parser = (function() {
     var prefix = (i > 0 ? "'..." : "'");
     var suffix = (stream.length - i > 12 ? "...'" : "'");
 
-    return ' at character ' + i + ', got ' + prefix + stream.slice(i, i+12) + suffix
+    return ' at line ' + index.line + ' column ' + index.column
+      +  ', got ' + prefix + stream.slice(i, i+12) + suffix
   }
 
   var formatError = Parsimmon.formatError = function(stream, error) {

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -296,13 +296,6 @@ Parsimmon.Parser = (function() {
     });
   };
 
-  _.markLineColumn = function() {
-    var indexLC = indexLineColumn;
-    return seqMap(indexLC, this, indexLC, function(start, value, end) {
-      return { start: start, value: value, end: end };
-    });
-  };
-
   _.desc = function(expected) {
     var self = this;
     return Parser(function(stream, i) {
@@ -424,19 +417,12 @@ Parsimmon.Parser = (function() {
     return parser;
   };
 
-  var index = Parsimmon.index = Parser(function(stream, i) {
-    return makeSuccess(i, i);
-  });
-
-  var indexLineColumn
-    = Parsimmon.indexLineColumn
+  var index
+    = Parsimmon.index
     = Parser(function(stream, i) {
-      // Like `index` above, but emitting an object that contains line and
-      // column indices in addition to the character-based one.
-
       var lines = stream.slice(0, i).split("\n");
-
-      // Unlike the character offset, lines and columns are 1-based.
+      // Note that unlike the character offset, the line and column offsets are
+      // 1-based.
       var lineWeAreUpTo = lines.length;
       var columnWeAreUpTo = lines[lines.length - 1].length + 1;
 

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -64,7 +64,7 @@ Parsimmon.Parser = (function() {
   }
 
   function formatGot(stream, error) {
-    var i = error.index;
+    var i = error.index.offset;
 
     if (i === stream.length) return ', got the end of the stream'
 
@@ -90,7 +90,7 @@ Parsimmon.Parser = (function() {
       value: result.value
     } : {
       status: false,
-      index: result.furthest,
+      index: makeLineColumnIndex(stream, result.furthest),
       expected: result.expected
     };
   };
@@ -417,20 +417,24 @@ Parsimmon.Parser = (function() {
     return parser;
   };
 
+  var makeLineColumnIndex = function(stream, i) {
+    var lines = stream.slice(0, i).split("\n");
+    // Note that unlike the character offset, the line and column offsets are
+    // 1-based.
+    var lineWeAreUpTo = lines.length;
+    var columnWeAreUpTo = lines[lines.length - 1].length + 1;
+
+    return {
+      offset: i,
+      line: lineWeAreUpTo,
+      column: columnWeAreUpTo
+    };
+  };
+
   var index
     = Parsimmon.index
     = Parser(function(stream, i) {
-      var lines = stream.slice(0, i).split("\n");
-      // Note that unlike the character offset, the line and column offsets are
-      // 1-based.
-      var lineWeAreUpTo = lines.length;
-      var columnWeAreUpTo = lines[lines.length - 1].length + 1;
-
-      return makeSuccess(i, {
-        offset: i,
-        line: lineWeAreUpTo,
-        column: columnWeAreUpTo
-      });
+      return makeSuccess(i, makeLineColumnIndex(stream, i));
     });
 
   //- fantasyland compat

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -296,6 +296,13 @@ Parsimmon.Parser = (function() {
     });
   };
 
+  _.markLineColumn = function() {
+    var indexLC = indexLineColumn;
+    return seqMap(indexLC, this, indexLC, function(start, value, end) {
+      return { start: start, value: value, end: end };
+    });
+  };
+
   _.desc = function(expected) {
     var self = this;
     return Parser(function(stream, i) {
@@ -420,6 +427,24 @@ Parsimmon.Parser = (function() {
   var index = Parsimmon.index = Parser(function(stream, i) {
     return makeSuccess(i, i);
   });
+
+  var indexLineColumn
+    = Parsimmon.indexLineColumn
+    = Parser(function(stream, i) {
+      // Like `index` above, but emitting an object that contains line and
+      // column indices in addition to the character-based one.
+
+      var lines = stream.slice(0, i).split("\n");
+
+      var lineWeAreUpTo = lines.length - 1;
+      var columnWeAreUpTo = lines[lines.length - 1].length;
+
+      return makeSuccess(i, {
+        offset: i,
+        line: lineWeAreUpTo,
+        column: columnWeAreUpTo
+      });
+    });
 
   //- fantasyland compat
 

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -11,7 +11,6 @@ suite('parser', function() {
   var alt = Parsimmon.alt;
   var all = Parsimmon.all;
   var index = Parsimmon.index;
-  var indexLineColumn = Parsimmon.indexLineColumn;
   var lazy = Parsimmon.lazy;
 
   test('Parsimmon.string', function() {
@@ -423,14 +422,7 @@ suite('parser', function() {
   });
 
   test('index', function() {
-    var parser = regex(/^x*/).then(index);
-    assert.equal(parser.parse('').value, 0);
-    assert.equal(parser.parse('xx').value, 2);
-    assert.equal(parser.parse('xxxx').value, 4);
-  });
-
-  test('indexLineColumn', function() {
-    var parser = regex(/^[x\n]*/).then(indexLineColumn);
+    var parser = regex(/^[x\n]*/).then(index);
     assert.deepEqual(parser.parse('').value, {
       offset: 0,
       line: 1,
@@ -450,13 +442,6 @@ suite('parser', function() {
 
   test('mark', function() {
     var ys = regex(/^y*/).mark()
-    var parser = optWhitespace.then(ys).skip(optWhitespace);
-    assert.deepEqual(parser.parse('').value, { start: 0, value: '', end: 0 });
-    assert.deepEqual(parser.parse(' yy ').value, { start: 1, value: 'yy', end: 3 });
-  });
-
-  test('markLineColumn', function() {
-    var ys = regex(/^y*/).markLineColumn()
     var parser = optWhitespace.then(ys).skip(optWhitespace);
     assert.deepEqual(
       parser.parse('').value,

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -19,10 +19,16 @@ suite('parser', function() {
     assert.ok(res.status);
     assert.equal(res.value, 'x');
 
-    res = parser.parse('y')
-    assert.ok(!res.status)
-    assert.equal("'x'", res.expected);
-    assert.equal(0, res.index);
+    res = parser.parse('y');
+    assert.deepEqual(res, {
+      status: false,
+      index: {
+        offset: 0,
+        line: 1,
+        column: 1
+      },
+      expected: ["'x'"]
+    });
 
     assert.equal(
       "expected 'x' at character 0, got 'y'",
@@ -37,12 +43,20 @@ suite('parser', function() {
     assert.equal(parser.parse('4').value, '4');
     assert.deepEqual(parser.parse('x0'), {
       status: false,
-      index: 0,
+      index: {
+        offset: 0,
+        line: 1,
+        column: 1
+      },
       expected: ['/[0-9]/']
     });
     assert.deepEqual(parser.parse('0x'), {
       status: false,
-      index: 1,
+      index: {
+        offset: 1,
+        line: 1,
+        column: 2
+      },
       expected: ['EOF']
     });
   });
@@ -62,12 +76,20 @@ suite('parser', function() {
       assert.deepEqual(parser.parse('(string between parens)').value, ['(', 'string between parens', ')']);
       assert.deepEqual(parser.parse('(string'), {
           status: false,
-          index: 7,
+          index: {
+            offset: 7,
+            line: 1,
+            column: 8
+          },
           expected: ["')'", "/[^\\)]/"]
       });
       assert.deepEqual(parser.parse('starts wrong (string between parens)'), {
           status: false,
-          index: 0,
+          index: {
+            offset: 0,
+            line: 1,
+            column: 1
+          },
           expected: ["'('"]
       });
   });
@@ -99,7 +121,15 @@ suite('parser', function() {
         });
       }
 
-      assert.deepEqual(failer().parse('a'), {status: false, index: 0, expected: ['nothing']})
+      assert.deepEqual(failer().parse('a'), {
+        status: false,
+        index: {
+          offset: 0,
+          line: 1,
+          column: 1
+        },
+        expected: ['nothing']}
+        )
     });
 
     test('composes with existing parsers', function(){
@@ -166,7 +196,11 @@ suite('parser', function() {
       assert.deepEqual(csvSep.parse('').value, []);
       assert.deepEqual(csvSep1.parse(''), {
         status: false,
-        index: 0,
+        index: {
+          offset: 0,
+          line: 1,
+          column: 1
+        },
         expected: ['/[a-zA-Z]+/']
       });
     });
@@ -175,7 +209,11 @@ suite('parser', function() {
       var input = 'Heres,a,csv,with,a,trailing,comma,';
       var output = {
         status: false,
-        index: 34,
+        index: {
+          offset: 34,
+          line: 1,
+          column: 35
+        },
         expected: ['/[a-zA-Z]+/']
       };
 
@@ -191,12 +229,20 @@ suite('parser', function() {
       assert.deepEqual(parser.parse('y'), {
         status: false,
         expected: ["'x'"],
-        index: 0
+        index: {
+          offset: 0,
+          line: 1,
+          column: 1
+        }
       })
       assert.deepEqual(parser.parse('xz'), {
         status: false,
         expected: ["'y'"],
-        index: 1
+        index: {
+          offset: 1,
+          line: 1,
+          column: 2
+        }
       });
     });
   });
@@ -362,7 +408,11 @@ suite('parser', function() {
 
       assert.deepEqual(parser.parse('y'), {
         status: false,
-        index: 1,
+        index: {
+          offset: 1,
+          line: 1,
+          column: 2
+        },
         expected: ['a character besides y']
       });
       assert.equal(parser.parse('x').value, 'x');
@@ -385,7 +435,11 @@ suite('parser', function() {
       assert.equal(parser.parse('x+y').value, '+');
       assert.deepEqual(parser.parse('x*y'), {
         status: false,
-        index: 2,
+        index: {
+          offset: 2,
+          line: 1,
+          column: 3
+        },
         expected: ['+']
       });
 
@@ -393,7 +447,11 @@ suite('parser', function() {
       assert.equal(parser.parse('x*y').value, '*');
       assert.deepEqual(parser.parse('x+y'), {
         status: false,
-        index: 2,
+        index: {
+          offset: 2,
+          line: 1,
+          column: 3
+        },
         expected: ['*']
       });
     });
@@ -479,7 +537,11 @@ suite('parser', function() {
 
         assert.deepEqual(parser.parse('abc'), {
           status: false,
-          index: 3,
+          index: {
+            offset: 3,
+            line: 1,
+            column: 4
+          },
           expected: ["'def'"]
         });
       });
@@ -489,7 +551,11 @@ suite('parser', function() {
 
         assert.deepEqual(parser.parse('abc'), {
           status: false,
-          index: 3,
+          index: {
+            offset: 3,
+            line: 1,
+            column: 4
+          },
           expected: ["'d'", "'def'"]
         });
       });
@@ -500,7 +566,11 @@ suite('parser', function() {
 
         assert.deepEqual(parser.parse('abcdef'), {
           status: false,
-          index: 6,
+          index: {
+            offset: 6,
+            line: 1,
+            column: 7
+          },
           expected: ["'g'"]
         });
       });
@@ -519,13 +589,21 @@ suite('parser', function() {
 
         assert.deepEqual(list.parse('(a b ()) c)'), {
           status: false,
-          index: 10,
+          index: {
+            offset: 10,
+            line: 1,
+            column: 11
+          },
           expected: ['EOF', "'('", "an atom"]
         });
 
         assert.deepEqual(list.parse('(a (b)) (() c'), {
           status: false,
-          index: 13,
+          index: {
+            offset: 13,
+            line: 1,
+            column: 14
+          },
           expected: ["')'", "'('", "an atom"]
         });
       });
@@ -538,7 +616,11 @@ suite('parser', function() {
 
         assert.deepEqual(parser.parse('aaabcde'), {
           status: false,
-          index: 5,
+          index: {
+            offset: 5,
+            line: 1,
+            column: 6
+          },
           expected: ["'def'"]
         });
       });
@@ -550,13 +632,21 @@ suite('parser', function() {
 
         assert.deepEqual(parser.parse('aabcde'), {
           status: false,
-          index: 4,
+          index: {
+            offset: 4,
+            line: 1,
+            column: 5
+          },
           expected: ["'def'"]
         });
 
         assert.deepEqual(parser.parse('aaaaabcde'), {
           status: false,
-          index: 7,
+          index: {
+            offset: 7,
+            line: 1,
+            column: 8
+          },
           expected: ["'def'"]
         });
       });
@@ -570,13 +660,21 @@ suite('parser', function() {
 
         assert.deepEqual(parser.parse('a'), {
           status: false,
-          index: 0,
+          index: {
+            offset: 0,
+            line: 1,
+            column: 1
+          },
           expected: ['the letter x']
         });
 
         assert.deepEqual(parser.parse('xa'), {
           status: false,
-          index: 1,
+          index: {
+            offset: 1,
+            line: 1,
+            column: 2
+          },
           expected: ['the letter y']
         });
       });
@@ -588,13 +686,21 @@ suite('parser', function() {
 
         assert.deepEqual(parser.parse('a'), {
           status: false,
-          index: 0,
+          index: {
+            offset: 0,
+            line: 1,
+            column: 1
+          },
           expected: ['the letter x']
         });
 
         assert.deepEqual(parser.parse('xa'), {
           status: false,
-          index: 1,
+          index: {
+            offset: 1,
+            line: 1,
+            column: 2
+          },
           expected: ['the letter y']
         });
       });

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -31,7 +31,7 @@ suite('parser', function() {
     });
 
     assert.equal(
-      "expected 'x' at character 0, got 'y'",
+      "expected 'x' at line 1 column 1, got 'y'",
       Parsimmon.formatError('y', res)
     );
   });

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -11,6 +11,7 @@ suite('parser', function() {
   var alt = Parsimmon.alt;
   var all = Parsimmon.all;
   var index = Parsimmon.index;
+  var indexLineColumn = Parsimmon.indexLineColumn;
   var lazy = Parsimmon.lazy;
 
   test('Parsimmon.string', function() {
@@ -428,11 +429,59 @@ suite('parser', function() {
     assert.equal(parser.parse('xxxx').value, 4);
   });
 
+  test('indexLineColumn', function() {
+    var parser = regex(/^[x\n]*/).then(indexLineColumn);
+    assert.deepEqual(parser.parse('').value, {
+      offset: 0,
+      line: 0,
+      column: 0
+    });
+    assert.deepEqual(parser.parse('xx').value, {
+      offset: 2,
+      line: 0,
+      column: 2
+    });
+    assert.deepEqual(parser.parse('xx\nxx').value, {
+      offset: 5,
+      line: 1,
+      column: 2
+    });
+  });
+
   test('mark', function() {
     var ys = regex(/^y*/).mark()
     var parser = optWhitespace.then(ys).skip(optWhitespace);
     assert.deepEqual(parser.parse('').value, { start: 0, value: '', end: 0 });
     assert.deepEqual(parser.parse(' yy ').value, { start: 1, value: 'yy', end: 3 });
+  });
+
+  test('markLineColumn', function() {
+    var ys = regex(/^y*/).markLineColumn()
+    var parser = optWhitespace.then(ys).skip(optWhitespace);
+    assert.deepEqual(
+      parser.parse('').value,
+      {
+        value: '',
+        start: { offset: 0, line: 0, column: 0 },
+        end: { offset: 0, line: 0, column: 0 }
+      }
+      );
+    assert.deepEqual(
+      parser.parse(' yy ').value,
+      {
+        value: 'yy',
+        start: { offset: 1, line: 0, column: 1 },
+        end: { offset: 3, line: 0, column: 3 }
+      }
+      );
+    assert.deepEqual(
+      parser.parse('\nyy ').value,
+      {
+        value: 'yy',
+        start: { offset: 1, line: 1, column: 0 },
+        end: { offset: 3, line: 1, column: 2 }
+      }
+      );
   });
 
   suite('smart error messages', function() {

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -433,18 +433,18 @@ suite('parser', function() {
     var parser = regex(/^[x\n]*/).then(indexLineColumn);
     assert.deepEqual(parser.parse('').value, {
       offset: 0,
-      line: 0,
-      column: 0
+      line: 1,
+      column: 1
     });
     assert.deepEqual(parser.parse('xx').value, {
       offset: 2,
-      line: 0,
-      column: 2
+      line: 1,
+      column: 3
     });
     assert.deepEqual(parser.parse('xx\nxx').value, {
       offset: 5,
-      line: 1,
-      column: 2
+      line: 2,
+      column: 3
     });
   });
 
@@ -462,24 +462,24 @@ suite('parser', function() {
       parser.parse('').value,
       {
         value: '',
-        start: { offset: 0, line: 0, column: 0 },
-        end: { offset: 0, line: 0, column: 0 }
+        start: { offset: 0, line: 1, column: 1 },
+        end: { offset: 0, line: 1, column: 1 }
       }
       );
     assert.deepEqual(
       parser.parse(' yy ').value,
       {
         value: 'yy',
-        start: { offset: 1, line: 0, column: 1 },
-        end: { offset: 3, line: 0, column: 3 }
+        start: { offset: 1, line: 1, column: 2 },
+        end: { offset: 3, line: 1, column: 4 }
       }
       );
     assert.deepEqual(
       parser.parse('\nyy ').value,
       {
         value: 'yy',
-        start: { offset: 1, line: 1, column: 0 },
-        end: { offset: 3, line: 1, column: 2 }
+        start: { offset: 1, line: 2, column: 1 },
+        end: { offset: 3, line: 2, column: 3 }
       }
       );
   });


### PR DESCRIPTION
Fix for #54, with tests.

I'm not sure about the naming: the new `_.markLineColumn` and `_.indexLineColumn` work just like `_.mark` and `_.index`, except they also include line and column information in offset data. The names are definitely descriptive, but a little clunky. Can anyone think of better ones?