### PR TITLE
Assert argument types and throw descriptive errors

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -53,8 +53,21 @@ Parsimmon.Parser = (function() {
     }
   }
 
+  // For ensuring we have the right argument types
   function assertParser(p) {
     if (!(p instanceof Parser)) throw new Error('not a parser: '+p);
+  }
+  function assertNumber(x) {
+    if (!(typeof x === 'number')) throw new Error('not a number: '+x);
+  }
+  function assertRegex(x) {
+    if (!(x instanceof RegExp)) throw new Error('not a regex: '+x);
+  }
+  function assertFunction(x) {
+    if (!(typeof x === 'function')) throw new Error('not a function: '+x);
+  }
+  function assertString(x) {
+    if (!(typeof x === 'string')) throw new Error('not a string: '+x);
   }
 
   function formatExpected(expected) {
@@ -100,6 +113,8 @@ Parsimmon.Parser = (function() {
     var parsers = [].slice.call(arguments);
     var numParsers = parsers.length;
 
+    parsers.forEach(assertParser);
+
     return Parser(function(stream, i) {
       var result;
       var accum = new Array(numParsers);
@@ -136,6 +151,8 @@ Parsimmon.Parser = (function() {
     var numParsers = parsers.length;
     if (numParsers === 0) return fail('zero alternates')
 
+    parsers.forEach(assertParser);
+
     return Parser(function(stream, i) {
       var result;
       for (var j = 0; j < parsers.length; j += 1) {
@@ -147,6 +164,7 @@ Parsimmon.Parser = (function() {
   };
 
   var sepBy = Parsimmon.sepBy = function(parser, separator) {
+    // Argument asserted by sepBy1
     return sepBy1(parser, separator).or(Parsimmon.of([]));
   };
 
@@ -237,6 +255,9 @@ Parsimmon.Parser = (function() {
     if (arguments.length < 2) max = min;
     var self = this;
 
+    assertNumber(min);
+    assertNumber(max);
+
     return Parser(function(stream, i) {
       var accum = [];
       var start = i;
@@ -278,6 +299,9 @@ Parsimmon.Parser = (function() {
   };
 
   _.map = function(fn) {
+
+    assertFunction(fn);
+
     var self = this;
     return Parser(function(stream, i) {
       var result = self._(stream, i);
@@ -310,6 +334,8 @@ Parsimmon.Parser = (function() {
     var len = str.length;
     var expected = "'"+str+"'";
 
+    assertString(str);
+
     return Parser(function(stream, i) {
       var head = stream.slice(i, i+len);
 
@@ -323,6 +349,10 @@ Parsimmon.Parser = (function() {
   };
 
   var regex = Parsimmon.regex = function(re, group) {
+
+    assertRegex(re);
+    if (group) assertNumber(group);
+
     var anchored = RegExp('^(?:'+re.source+')', (''+re).slice((''+re).lastIndexOf('/')+1));
     var expected = '' + re;
     if (group == null) group = 0;
@@ -374,6 +404,8 @@ Parsimmon.Parser = (function() {
   });
 
   var test = Parsimmon.test = function(predicate) {
+    assertFunction(predicate);
+
     return Parser(function(stream, i) {
       var char = stream.charAt(i);
       if (i < stream.length && predicate(char)) {
@@ -394,6 +426,8 @@ Parsimmon.Parser = (function() {
   };
 
   var takeWhile = Parsimmon.takeWhile = function(predicate) {
+    assertFunction(predicate);
+
     return Parser(function(stream, i) {
       var j = i;
       while (j < stream.length && predicate(stream.charAt(j))) j += 1;

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -28,6 +28,8 @@ suite('parser', function() {
       "expected 'x' at character 0, got 'y'",
       Parsimmon.formatError('y', res)
     );
+
+    assert.throws(function() { string(34) });
   });
 
   test('Parsimmon.regex', function() {
@@ -45,6 +47,8 @@ suite('parser', function() {
       index: 1,
       expected: ['EOF']
     });
+    assert.throws(function() { regex(42) });
+    assert.throws(function() { regex(/a/, 'not a number') });
   });
 
   test('Parsimmon.regex with group', function() {
@@ -70,6 +74,7 @@ suite('parser', function() {
           index: 0,
           expected: ["'('"]
       });
+      assert.throws(function() { seq('not a parser') });
   });
 
   suite('Parsimmon.custom', function(){
@@ -144,6 +149,8 @@ suite('parser', function() {
          type: 'identifier',
          value: 'anIdentifier'
       });
+
+      assert.throws(function() { alt('not a parser') });
   });
 
   suite('Parsimmon.sepBy/sepBy1', function() {
@@ -160,6 +167,10 @@ suite('parser', function() {
 
       assert.deepEqual(csvSep.parse(input).value, output);
       assert.deepEqual(csvSep1.parse(input).value, output);
+      assert.throws(function() { Parsimmon.sepBy('not a parser') });
+      assert.throws(function() {
+        Parsimmon.sepBy(string('a'), 'not a parser')
+      });
     });
 
     test('sepBy succeeds with the empty list on empty input, sepBy1 fails', function() {
@@ -199,6 +210,11 @@ suite('parser', function() {
         index: 1
       });
     });
+    test('errors when argument is not a parser', function() {
+      assert.throws(function() {
+        string('x').then('not a parser')
+      });
+    });
   });
 
   suite('chain', function() {
@@ -234,6 +250,9 @@ suite('parser', function() {
       assert.deepEqual(parser.parse('x'), { status: true, value: 'y' });
       assert.equal(piped, 'x');
     });
+    test('asserts that a function was given', function() {
+      assert.throws(function() { string('x').map('not a function') });
+    });
   });
 
   suite('result', function() {
@@ -249,6 +268,9 @@ suite('parser', function() {
 
       assert.deepEqual(parser.parse('xy'), { status: true, value: 'x' });
       assert.ok(!parser.parse('x').status);
+    });
+    test('asserts that a parser was given', function() {
+      assert.throws(function() { string('x').skip('not a parser') });
     });
   });
 
@@ -270,6 +292,9 @@ suite('parser', function() {
       assert.equal(parser.parse('\\y').value, 'y');
       assert.equal(parser.parse('z').value, 'z');
       assert.ok(!parser.parse('\\z').status);
+    });
+    test('asserts that a parser was given', function() {
+      assert.throws(function() { string('x').or('not a parser') });
     });
   });
 
@@ -349,6 +374,12 @@ suite('parser', function() {
       assert.deepEqual(atLeastTwo.parse('xyzw').value, ['x', 'y', 'z', 'w']);
       assert.ok(!atLeastTwo.parse('x').status);
     });
+    test('checks that argument types are correct', function() {
+      assert.throws(function() { string('x').times('not a number') });
+      assert.throws(function() { string('x').times(1, 'not a number') });
+      assert.throws(function() { string('x').atLeast('not a number') });
+      assert.throws(function() { string('x').atMost('not a number') });
+    });
   });
 
   suite('fail', function() {
@@ -410,6 +441,7 @@ suite('parser', function() {
     var parser = Parsimmon.test(function(ch) { return ch !== '.' });
     assert.equal(parser.parse('x').value, 'x');
     assert.equal(parser.parse('.').status, false);
+    assert.throws(function() { Parsimmon.test('not a function') });
   });
 
   test('takeWhile', function() {
@@ -419,6 +451,7 @@ suite('parser', function() {
     assert.equal(parser.parse('abc.').value, 'abc');
     assert.equal(parser.parse('.').value, '');
     assert.equal(parser.parse('').value, '');
+    assert.throws(function() { Parsimmon.takeWhile('not a function') });
   });
 
   test('index', function() {


### PR DESCRIPTION
Fixes #59 by checking that functions exposed to the user are passed the right types of argument.  This avoids annoyances by catching errors earlier and giving a descriptive error.

Currently, some obviously wrong stuff like—

    string({ hi : 'there' })

—doesn't error until `.parse` is called on it.

Also, this mysterious beast—

    p.string('a').times('wat').parse("")

—actually runs and returns `{ status: true, value: [] }`, which is fascinating but terrible.

With these changes, those go away. Unit tests to back it up.