### PR TITLE
Remove redundant pjs dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "chai": "1.5.x",
     "uglify-js": "2.x"
   },
-  "dependencies": {
-    "pjs": "5.x"
-  },
+  "dependencies": {},
   "scripts": {
     "test": "make test"
   }


### PR DESCRIPTION
The [changelog mentions](https://github.com/jneen/parsimmon/blob/master/CHANGELOG.md#version-060-2015-02-24) it's unnecessary, and it's no longer used in code.