### PR TITLE
Fix parser.or API documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -267,14 +267,14 @@ These methods are all called off of existing parsers, not from the `Parsimmon` o
 Returns a new parser which tries `parser`, and if it fails uses `otherParser`. Example:
 
 ```javascript
-var maybePlus =
+var numberPrefix =
   Parsimmon.string('+')
     .or(Parsimmon.string('-'))
     .or(Parsimmon.of(''));
 
-maybePlus.parse('+'); // => {status: true, value: '+'}
-maybePlus.parse('-'); // => {status: true, value: '-'}
-maybePlus.parse('');  // => {status: true, value: ''}
+numberPrefix.parse('+'); // => {status: true, value: '+'}
+numberPrefix.parse('-'); // => {status: true, value: '-'}
+numberPrefix.parse('');  // => {status: true, value: ''}
 ```
 
 ## parser.chain(newParserFunc)

--- a/API.md
+++ b/API.md
@@ -267,10 +267,10 @@ These methods are all called off of existing parsers, not from the `Parsimmon` o
 Returns a new parser which tries `parser`, and if it fails uses `otherParser`. Example:
 
 ```javascript
-var numberPrefix =
+var maybePlus =
   Parsimmon.string('+')
-    .or(Parsimmin.of('-'))
-    .or(Parsimmin.of(''));
+    .or(Parsimmon.string('-'))
+    .or(Parsimmon.of(''));
 
 maybePlus.parse('+'); // => {status: true, value: '+'}
 maybePlus.parse('-'); // => {status: true, value: '-'}


### PR DESCRIPTION
Fixed API documentation example for `parser.or` method, as referenced in #116

Furthermore, changed the parser name.