### PR TITLE
Add `fallback` Parser method

### DIFF
--- a/API.md
+++ b/API.md
@@ -333,7 +333,7 @@ Returns a new parser with the same behavior, but which yields `value`. Equivalen
 
 ## parser.else(value)
 
-Returns a new parser which tries `parser` and, if it fails, yields `value` without consuming any character of the stream. Available also as `parser.else_(value)` to provide ES3 compatibility.
+Returns a new parser which tries `parser` and, if it fails, yields `value` without consuming any character of the stream. Available also as `parser.else_(value)` to provide ES3 compatibility. Equivalent to `parser.or(Parsimmon.of(value))`.
 
 ```js
 var digitOrZero = Parsimmon.digit.else('0');

--- a/API.md
+++ b/API.md
@@ -270,7 +270,7 @@ Returns a new parser which tries `parser`, and if it fails uses `otherParser`. E
 var numberPrefix =
   Parsimmon.string('+')
     .or(Parsimmon.string('-'))
-    .else('');
+    .fallback('');
 
 numberPrefix.parse('+'); // => {status: true, value: '+'}
 numberPrefix.parse('-'); // => {status: true, value: '-'}
@@ -331,12 +331,12 @@ pNum.parse('3.1'); // => {status: true, value: 3.1}
 
 Returns a new parser with the same behavior, but which yields `value`. Equivalent to `parser.map(function(x) { return x; }.bind(value))`.
 
-## parser.else(value)
+## parser.fallback(value)
 
-Returns a new parser which tries `parser` and, if it fails, yields `value` without consuming any character of the stream. Available also as `parser.else_(value)` to provide ES3 compatibility. Equivalent to `parser.or(Parsimmon.of(value))`.
+Returns a new parser which tries `parser` and, if it fails, yields `value` without consuming any character of the stream. Equivalent to `parser.or(Parsimmon.of(value))`.
 
 ```js
-var digitOrZero = Parsimmon.digit.else('0');
+var digitOrZero = Parsimmon.digit.fallback('0');
 
 digitOrZero.parse('4'); // => {status: true, value: '4'}
 digitOrZero.parse('');  // => {status: true, value: '0'}

--- a/API.md
+++ b/API.md
@@ -270,7 +270,7 @@ Returns a new parser which tries `parser`, and if it fails uses `otherParser`. E
 var numberPrefix =
   Parsimmon.string('+')
     .or(Parsimmon.string('-'))
-    .or(Parsimmon.of(''));
+    .else('');
 
 numberPrefix.parse('+'); // => {status: true, value: '+'}
 numberPrefix.parse('-'); // => {status: true, value: '-'}
@@ -330,6 +330,17 @@ pNum.parse('3.1'); // => {status: true, value: 3.1}
 ## parser.result(value)
 
 Returns a new parser with the same behavior, but which yields `value`. Equivalent to `parser.map(function(x) { return x; }.bind(value))`.
+
+## parser.else(value)
+
+Returns a new parser which tries `parser` and, if it fails, yields `value` without consuming any character of the stream. Available also as `parser.else_(value)` to provide ES3 compatibility.
+
+```js
+var digitOrZero = Parsimmon.digit.else('0');
+
+digitOrZero.parse('4'); // => {status: true, value: '4'}
+digitOrZero.parse('');  // => {status: true, value: '0'}
+```
 
 ## parser.skip(otherParser)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 * **BREAKING:** `parser.empty` is now a function (`parser.empty()`)
 * `Parsimmon.Parser.empty()` is a copy of `parser.empty()`
 * Adds `Parsimmon.isParser`
-* Documentation for `Parsimmon.formatError`
+* Adds `parser.fallback`
+* Documentation for `Parsimmon.formatError`, `Parsimmon.parse`
 
 ## version 0.9.2 (2016-08-07)
 

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -420,12 +420,9 @@
     });
   };
 
-  _.else = function(result) {
+  _.fallback = function(result) {
     return this.or(succeed(result));
   };
-
-  //- ES3 compatibility
-  _.else_ = _.else;
 
   // -*- primitive parsers -*- //
   function string(str) {

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -420,6 +420,13 @@
     });
   };
 
+  _.else = function(result) {
+    return this.or(succeed(result));
+  };
+
+  //- ES3 compatibility
+  _.else_ = _.else;
+
   // -*- primitive parsers -*- //
   function string(str) {
     assertString(str);

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -441,6 +441,20 @@ suite('parser', function() {
     });
   });
 
+  suite('else', function() {
+    test('allows fallback result if no match is found', function() {
+      var parser = string('a').else('nothing');
+
+      assert.deepEqual(parser.parse('a').value, 'a');
+      assert.deepEqual(parser.parse('').value, 'nothing');
+    });
+
+    test('allows es3 compatible syntax \'else_\'', function() {
+      var parser = string('a').else_('b');
+      assert.isTrue(Parsimmon.isParser(parser));
+    });
+  });
+
   suite('or', function() {
     test('two parsers', function() {
       var parser = string('x').or(string('y'));

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -441,17 +441,12 @@ suite('parser', function() {
     });
   });
 
-  suite('else', function() {
+  suite('fallback', function() {
     test('allows fallback result if no match is found', function() {
-      var parser = string('a').else('nothing');
+      var parser = string('a').fallback('nothing');
 
       assert.deepEqual(parser.parse('a').value, 'a');
       assert.deepEqual(parser.parse('').value, 'nothing');
-    });
-
-    test('allows es3 compatible syntax \'else_\'', function() {
-      var parser = string('a').else_('b');
-      assert.isTrue(Parsimmon.isParser(parser));
     });
   });
 


### PR DESCRIPTION
Parser `else` method, equals to `or(Parsimmon.of(…))`. #105 

```js
var parser = P.string('a').else('x');

parser.parse('a').value; // => 'a'
parser.parse('').value;   // => 'x'
```

Includes test & doc :smile: 

Talking about the name: It seems to me that `default` may be a nice one, since this method is just providing a value if parser fails, and does *not* consume characters from the stream

```js
var parser = P.letters.default('empty');
```