### PR TITLE
Add lookahead function

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -425,6 +425,9 @@
     });
   };
 
+  _.lookahead = function(x) {
+    return this.skip(lookahead(x));
+  };
   _.desc = function(expected) {
     var self = this;
     return Parsimmon(function(input, i) {
@@ -492,6 +495,30 @@
     return Parsimmon(function(input, i) {
       return makeFailure(i, expected);
     });
+  }
+
+  function lookahead(x) {
+    if (typeof x === 'string') {
+      // similar to string, but does not consume
+      return Parsimmon(function(input, i) {
+        var j = i + x.length;
+        var head = input.slice(i, j);
+        if (head === x) {
+          return makeSuccess(i, '');
+        } else {
+          return makeFailure(i, x);
+        }
+      });
+    } else if (x instanceof RegExp) {
+      var regexp = RegExp('^(?:' + x.source + ')', flags(x));
+      return Parsimmon(function(str, i) {
+        if (regexp.test(str.slice(i))) {
+          return Parsimmon.makeSuccess(i, '');
+        }
+        return Parsimmon.makeFailure(i, '' + regexp);
+      });
+    }
+    throw new Error('not a string or regexp: '+x);
   }
 
   var any = Parsimmon(function(input, i) {
@@ -642,6 +669,7 @@
   Parsimmon.lazy = lazy;
   Parsimmon.letter = letter;
   Parsimmon.letters = letters;
+  Parsimmon.lookahead = lookahead;
   Parsimmon.makeFailure = makeFailure;
   Parsimmon.makeSuccess = makeSuccess;
   Parsimmon.noneOf = noneOf;

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -510,12 +510,13 @@
         }
       });
     } else if (x instanceof RegExp) {
+      assertRegexp(x);
       var regexp = RegExp('^(?:' + x.source + ')', flags(x));
       return Parsimmon(function(str, i) {
         if (regexp.test(str.slice(i))) {
-          return Parsimmon.makeSuccess(i, '');
+          return makeSuccess(i, '');
         }
-        return Parsimmon.makeFailure(i, '' + regexp);
+        return makeFailure(i, '' + regexp);
       });
     }
     throw new Error('not a string or regexp: '+x);

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -14,6 +14,7 @@ suite('parser', function() {
   var index = Parsimmon.index;
   var lazy = Parsimmon.lazy;
   var fail = Parsimmon.fail;
+  var lookahead = Parsimmon.lookahead;
 
   function equivalentParsers(p1, p2, inputs) {
     for (var i = 0; i < inputs.length; i++) {
@@ -118,6 +119,48 @@ suite('parser', function() {
     var input = '';
     var answer = Parsimmon.formatError(input, parser.parse(input));
     assert.deepEqual(answer, expectation);
+  });
+
+  suite('Parsimmon.lookahead', function() {
+    test('should handle string', function() {
+      lookahead('');
+    });
+    test('should handle regexp', function() {
+      lookahead(/./);
+    });
+    test('can be chained as prototype', function() {
+      var parser = seq(
+        string('abc').lookahead('d'),
+        string('d')
+      );
+      var answer = parser.parse('abcd');
+      assert.deepEqual(answer.value, ['abc', 'd']);
+    });
+    test('does not consume string', function() {
+      var parser = seq(
+        string('abc'),
+        lookahead('d'),
+        string('d')
+      );
+      var answer = parser.parse('abcd');
+      assert.deepEqual(answer.value, ['abc', '', 'd']);
+    });
+    test('does not consume regex', function() {
+      var parser = seq(
+        string('abc'),
+        lookahead(/d/),
+        string('d')
+      );
+      var answer = parser.parse('abcd');
+      assert.deepEqual(answer.value, ['abc', '', 'd']);
+    });
+    test('raises error if argument is not string or regexp', function() {
+      try {
+        lookahead(new Object());
+      } catch (err) {
+        true;
+      }
+    });
   });
 
   test('Parsimmon.regex', function() {

--- a/test/parsimmon.test.js
+++ b/test/parsimmon.test.js
@@ -155,11 +155,10 @@ suite('parser', function() {
       assert.deepEqual(answer.value, ['abc', '', 'd']);
     });
     test('raises error if argument is not string or regexp', function() {
-      try {
-        lookahead(new Object());
-      } catch (err) {
-        true;
-      }
+      assert.throws(function() {lookahead({});});
+      assert.throws(function() {lookahead([]);});
+      assert.throws(function() {lookahead(true);});
+      assert.throws(function() {lookahead(12);});
     });
   });
 


### PR DESCRIPTION
closes #136 
- string and regex support
- provides as P.lookahead and P.prototype.lookahead for convenience