### PR TITLE
Add optional function to `skip()`

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -411,8 +411,15 @@
   };
   _['fantasy-land/map'] = _.map;
 
-  _.skip = function(next) {
-    return seq(this, next).map(function(results) { return results[0]; });
+  _.skip = function(next, fn) {
+    var numArgs = arguments.length;
+    return seq(this, next).map(function(results) {
+      if (numArgs >= 2) {
+        assertFunction(fn);
+        fn.call(null, results[1]);
+      }
+      return results[0];
+    });
   };
 
   _.mark = function() {


### PR DESCRIPTION
If you supply a function as a second argument to skip() it will be called
with text it consumed.

This allows to have side effects which won't yield any result.

Example:

    var skipped_chars = '';
    P.string('x').skip(P.string('y'), function(char) {
        skipped_chars += char;
    });

I'm totally unsure if that makes sense and whether there is a better way. I just felt like it's easier to show some code instead of trying to describe what I'm after.