### PR TITLE
Force LF line endings to fix eslint errors on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
This fixes the bajillion errors generated when running tests on Windows.