### PR TITLE
WIP this probably works now?

### DIFF
--- a/API.md
+++ b/API.md
@@ -395,27 +395,50 @@ Parsimmon.regexp(/[ ]*/).map(function(str) {
 })
 ```
 
-## Parsimmon.initialStateIndent
-
-**TODO**
-
 ## Parsimmon.countIndentation
 
-**TODO**
+This parser accepts zero or more spaces **or** zero or more tabs, then returns the number of characters consumed. Tabs count as one character. Mixed spaces and tabs are not supported. This is intended to be passed as an argument to `Parsimmon.indentMore`, `Parsimmon.indentLess`, and `Parsimmon.indentSame`.
+
+**Note:** This is slightly less involved than the [indentation rules offered by Python](https://docs.python.org/3/reference/lexical_analysis.html#indentation). Feel free to implement your own indentation counting parser to suit your own needs. That's what the `Parsimmon.indent*` parsers take a parameter.
+
+Example:
+
+```js
+Parsimmon.countIndentation.tryParse('  ');
+// => 2
+
+Parsimmon.countIndentation.tryParse('\t\t\t');
+// => 3
+
+// Fails on mixed tabs and spaces.
+Parsimmon.countIndentation.parse('\t\t ').status;
+// => false
+```
 
 ## Parsimmon.indentMore(parser)
 
-**TODO**
+Using the indentation count returned from `parser`, succeed if the new indentation count is greater than the current indentation count. Adds the new indentation count to the end of the parser state array.
 
+See the `python-ish.js` file in the `examples/` directory for a complete example of how to use this parser.
+
+**Note:** This parser assumes the parsing state is an array of numbers, with `0` as the first item. Parsimmon sets this up by default if you don't pass an initial state parameter to `.parse` or `.tryParse`.
 
 ## Parsimmon.indentLess(parser)
 
-**TODO**
+Using the indentation count returned from `parser`, succeed if the new indentation count is less than the current indentation count **and** the new indentation level is equal to one already in the parser state array. Removes the last item from the end of the parser state array.
+
+See the `python-ish.js` file in the `examples/` directory for a complete example of how to use this parser.
+
+**Note:** This parser assumes the parsing state is an array of numbers, with `0` as the first item. Parsimmon sets this up by default if you don't pass an initial state parameter to `.parse` or `.tryParse`.
 
 
 ## Parsimmon.indentSame(parser)
 
-**TODO**
+Using the indentation count returned from `parser`, succeed if the new indentation count is equal to the current indentation count.
+
+See the `python-ish.js` file in the `examples/` directory for a complete example of how to use this parser.
+
+**Note:** This parser assumes the parsing state is an array of numbers, with `0` as the first item. Parsimmon sets this up by default if you don't pass an initial state parameter to `.parse` or `.tryParse`.
 
 ## Parsimmon.letter
 

--- a/API.md
+++ b/API.md
@@ -395,6 +395,14 @@ Parsimmon.regexp(/[ ]*/).map(function(str) {
 })
 ```
 
+## Parsimmon.initialStateIndent
+
+**TODO**
+
+## Parsimmon.countIndentation
+
+**TODO**
+
 ## Parsimmon.indentMore(parser)
 
 **TODO**

--- a/API.md
+++ b/API.md
@@ -12,6 +12,63 @@ The string passed to `.parse` is called the *input*.
 
 A parser is said to *consume* the text that it parses, leaving only the unconsumed text for subsequent parsers to check.
 
+# Tips
+
+## Readability
+
+For the sake of readability in your own parsers, it's recommended to either create a shortcut for the Parsimmon library:
+
+```javascript
+var P = Parsimmon;
+var parser = P.digits.sepBy(P.whitespace);
+```
+
+Or to create shortcuts for the Parsimmon values you intend to use (when using Babel):
+
+```javascript
+import { digits, whitespace } from 'parsimmon';
+var parser = digits.sepBy(whitespace);
+```
+
+Because it can become quite wordy to repeat Parsimmon everywhere:
+
+```javascript
+var parser = Parsimmon.sepBy(Parsimmon.digits, Parsimmon.whitespace);
+```
+
+For clarity's sake, however, `Parsimmon` will refer to the Parsimmon library itself, and `parser` will refer to a parser being used as an object in a method, like `P.string('9')` in `P.string('9').map(Number)`.
+
+## Side effects
+
+Do not perform [side effects](https://en.wikipedia.org/wiki/Side_effect_(computer_science)) parser actions. This is potentially unsafe, as Parsimmon will backtrack between parsers, but there's no way to undo your side effects.
+
+Side effects include pushing to an array, modifying an object, or `console.log`.
+
+In this example, the parser `pVariable` is called twice on the same text because of `Parsimmon.alt` backtracking, and has a side effect (pushing to an array) inside its `.map` method, so we get two items in the array instead of just one.
+
+```js
+var x = 0;
+var variableNames = [];
+var pVariable =
+  Parsimmon.regexp(/[a-z]+/i)
+    .map(function(name) {
+      variableNames.push(name);
+      return name;
+    });
+var pDeclaration =
+  Parsimmon.alt(
+    Parsimmon.string('var ').then(pVariable).then(Parsimmon.string('\n')),
+    Parsimmon.string('var ').then(pVariable).then(Parsimmon.string(';'))
+  );
+pDeclaration.parse('var gummyBear;');
+console.log(variableNames);
+// => ['gummyBear', 'gummyBear']
+```
+
+## Custom parsers
+
+`Parsimmon.custom(fn)` is no longer recommended, please use `Parsimmon(fn)` instead. That being said, *most* of the time you will not need to ever create a custom parser using `Parsimmon(fn)`. Custom parsers have access to internal parsing state, which is primarily useful if you are parsing an indentation-sensitive language, such as Python. That being said, the functions `Parsimmon.indentMore`, `Parsimmon.indentLess`, and `Parsimmon.indentSame` are designed to handle that sort of thing for you anyway, so you still might not need to do it.
+
 # Base parsers and parser generators
 
 These are either parsers or functions that return new parsers. These are the building blocks of parsers. They are all contained in the `Parsimmon` object.
@@ -53,17 +110,46 @@ Lang.Value.tryParse('(list 1 2 foo (list nice 3 56 989 asdasdas))');
 
 ## Parsimmon(fn)
 
-**NOTE:** You probably will never need to use this function. Most parsing can be accomplished using `Parsimmon.regexp` and combination with `Parsimmon.seq` and `Parsimmon.alt`.
+**NOTE:** You probably will never need to use this function. Most parsing can be accomplished using `Parsimmon.regexp` and combination with `Parsimmon.seq` and `Parsimmon.alt`, and friends.
 
 You can add a primitive parser (similar to the included ones) by using `Parsimmon(fn)`. This is an example of how to create a parser that matches any character except the one provided:
 
+- The parameter `input` is the entire string passed to `.parse` or `.tryParse`.
+- The paremter `i` is the current parsing index into the `input` string.
+- The parameter `state` is the current parsing state. Generally this is not necessary, but parsing indentation-sensitive languages such as Python requires maintaining some state during parsing, so this is provided for such tasks.
+
+The return value from a custom parser should is somewhat complicated, so `Parsimmon.makeSuccess(i, value, state)` and `Parsimmon.makeFailure(i, expected, state)` are provided to ease implementation.
+
+**NOTE**: You should not modify `state`. Parsimmon does not track changes to it, so if your parser backtracks at any point, you may end up with incorrect state. Example:
+
+```js
+// -*- BAD -*-
+// Do not modify state
+state[key] = value;
+state.member = value;
+state.push(value);
+state.unshift(value);
+state.number++;
+
+// -*- GOOD -*-
+// Use new state based on old state
+var newState = Object.assign({}, state, {[key]: value});
+var newState = Object.assign({}, state, {member: value});
+var newState = state.concat([value]);
+var newState = [value].concat(state);
+var newState = Object.assign({}, state, {number: state.number + 1});
+```
+
+That example uses some ES6 features for the sake of brevity, but rest assured that libraries like Lodash can provide similar functionality as `Object.assign` if you need to target ES5 environments.
+
 ```javascript
 function notChar(char) {
-  return Parsimmon(function(input, i) {
+  return Parsimmon(function(input, i, state) {
     if (input.charAt(i) !== char) {
-      return Parsimmon.makeSuccess(i + 1, input.charAt(i));
+      return Parsimmon.makeSuccess(i + 1, input.charAt(i), state);
     }
-    return Parsimmon.makeFailure(i, 'anything different than "' + char + '"');
+    var expected = 'anything different than "' + char + '"';
+    return Parsimmon.makeFailure(i, expected, state);
   });
 }
 ```
@@ -84,13 +170,13 @@ parser.parse('accccc');
 
 Alias of `Parsimmon(fn)` for backwards compatibility.
 
-## Parsimmon.makeSuccess(index, value)
+## Parsimmon.makeSuccess(index, value, state)
 
-To be used inside of `Parsimmon(fn)`. Generates an object describing how far the successful parse went (`index`), and what `value` it created doing so. See documentation for `Parsimmon(fn)`.
+To be used inside of `Parsimmon(fn)`. Generates an object describing how far the successful parse went (`index`), what `value` it created doing so, and the new `state` after it's done. See documentation for `Parsimmon(fn)`.
 
-## Parsimmon.makeFailure(furthest, expectation)
+## Parsimmon.makeFailure(furthest, expectation, state)
 
-To be used inside of `Parsimmon(fn)`. Generates an object describing how far the unsuccessful parse went (`index`), and what kind of syntax it expected to see (`expectation`). See documentation for `Parsimmon(fn)`.
+To be used inside of `Parsimmon(fn)`. Generates an object describing how far the unsuccessful parse went (`index`), what kind of syntax it expected to see (`expectation`), and what the parsing `state` before it failed. See documentation for `Parsimmon(fn)`.
 
 ## Parsimmon.isParser(obj)
 
@@ -297,6 +383,32 @@ Equivalent to `Parsimmon.lazy(f).desc(description)`.
 
 Returns a failing parser with the given message.
 
+## Parsimmon.countSpaces
+
+Parser that expectes zero or more spaces and yields the number of spaces consumed. Intended to be used with the `Parsimmon.indent*` family of functions.
+
+Equivalent to:
+
+```js
+Parsimmon.regexp(/[ ]*/).map(function(str) {
+  return str.length;
+})
+```
+
+## Parsimmon.indentMore(parser)
+
+**TODO**
+
+
+## Parsimmon.indentLess(parser)
+
+**TODO**
+
+
+## Parsimmon.indentSame(parser)
+
+**TODO**
+
 ## Parsimmon.letter
 
 Equivalent to `Parsimmon.regexp(/[a-z]/i)`.
@@ -395,7 +507,7 @@ CustomString.parse('%<a string>'); // => {status: true, value: 'a string'}
 
 ## Parsimmon.custom(fn)
 
-**Deprecated:** Please use `Parsimmon(fn)` going forward.
+**DEPRECATED:** Please use `Parsimmon(fn)` going forward.
 
 You can add a primitive parser (similar to the included ones) by using `Parsimmon.custom`. This is an example of how to create a parser that matches any character except the one provided:
 
@@ -455,6 +567,10 @@ parser.parse('ccc');
 //     expected: ["'a' character", "'b' character"]}
 ```
 
+## parser.parse(input, initialState)
+
+Like `.parse(input)`, but passes `initialState` to the parser. When omitted, `initialState` is set to `[0]` for use with `Parsimmon.indentMore`, `Parsimmon.indentLess`, and `Parsimmon.indentSame`.
+
 ## parser.tryParse(input)
 
 Like `parser.parse(input)` but either returns the parsed value or throws an error on failure. The error object contains additional properties about the error.
@@ -480,6 +596,10 @@ try {
   //     expected: ['EOF', 'whitespace']}
 }
 ```
+
+## parser.tryParse(input, initialState)
+
+Like `.tryParse(input)`, but passes `initialState` to the parser. When omitted, `initialState` is set to `[0]` for use with `Parsimmon.indentMore`, `Parsimmon.indentLess`, and `Parsimmon.indentSame`.
 
 ## parser.or(otherParser)
 
@@ -886,56 +1006,3 @@ See `parser.chain(newParserFunc)` defined earlier.
 ## parser.of(result)
 
 Equivalent to `Parsimmon.of(result)`.
-
-# Tips
-
-## Readability
-
-For the sake of readability in your own parsers, it's recommended to either create a shortcut for the Parsimmon library:
-
-```javascript
-var P = Parsimmon;
-var parser = P.digits.sepBy(P.whitespace);
-```
-
-Or to create shortcuts for the Parsimmon values you intend to use (when using Babel):
-
-```javascript
-import { digits, whitespace } from 'parsimmon';
-var parser = digits.sepBy(whitespace);
-```
-
-Because it can become quite wordy to repeat Parsimmon everywhere:
-
-```javascript
-var parser = Parsimmon.sepBy(Parsimmon.digits, Parsimmon.whitespace);
-```
-
-For clarity's sake, however, `Parsimmon` will refer to the Parsimmon library itself, and `parser` will refer to a parser being used as an object in a method, like `P.string('9')` in `P.string('9').map(Number)`.
-
-## Side effects
-
-Do not perform [side effects](https://en.wikipedia.org/wiki/Side_effect_(computer_science)) parser actions. This is potentially unsafe, as Parsimmon will backtrack between parsers, but there's no way to undo your side effects.
-
-Side effects include pushing to an array, modifying an object, or `console.log`.
-
-In this example, the parser `pVariable` is called twice on the same text because of `Parsimmon.alt` backtracking, and has a side effect (pushing to an array) inside its `.map` method, so we get two items in the array instead of just one.
-
-```js
-var x = 0;
-var variableNames = [];
-var pVariable =
-  Parsimmon.regexp(/[a-z]+/i)
-    .map(function(name) {
-      variableNames.push(name);
-      return name;
-    });
-var pDeclaration =
-  Parsimmon.alt(
-    Parsimmon.string('var ').then(pVariable).then(Parsimmon.string('\n')),
-    Parsimmon.string('var ').then(pVariable).then(Parsimmon.string(';'))
-  );
-pDeclaration.parse('var gummyBear;');
-console.log(variableNames);
-// => ['gummyBear', 'gummyBear']
-```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * `.tryParse`
   * `Parsimmon.makeSuccess`
   * `Parsimmon.makeFailure`
+* Adds `Parsimmon.initialStateIndent`
+* Adds `Parsimmon.countIndentation`
 * Adds `Parsimmon.indentMore`
 * Adds `Parsimmon.indentLess`
 * Adds `Parsimmon.indentSame`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## version 2.0.0 (????-??-??)
+
+* **BREAKING:** Adds optional `initialState` parameter to:
+  * `.parse`
+  * `.tryParse`
+* **BREAKING:** Adds extra `state` parameter to:
+  * `.parse`
+  * `.tryParse`
+  * `Parsimmon.makeSuccess`
+  * `Parsimmon.makeFailure`
+* Adds `Parsimmon.indentMore`
+* Adds `Parsimmon.indentLess`
+* Adds `Parsimmon.indentSame`
+
 ## version 1.6.1 (2017-07-01)
 
 * **100% unit test coverage!** This does not mean bugs won't exist, but it keeps us much safer against regressions in the future.

--- a/examples/python-ish.js
+++ b/examples/python-ish.js
@@ -60,7 +60,7 @@ block:
       block:
         ba()
         bb()
-       bc()
+        bc()
       e()
 f()
 `;

--- a/examples/python-ish.js
+++ b/examples/python-ish.js
@@ -7,96 +7,46 @@ let P = require('..');
 
 ///////////////////////////////////////////////////////////////////////
 
-// LIMITATIONS: Python allows not only multiline blocks, but inline blocks too.
-//
-//   if x == y: print("nice")
-//
-// vs.
-//
-//   if x == y:
-//       print("nice")
-//
-// This parser only supports the multiline indented form.
-
-// NOTE: This is a hack and is not recommended. Maintaining state throughout
-// Parsimmon parsers is not reliable since backtracking may occur, leaving your
-// state inaccurate. See the relevant GitHub issue for discussion.
-//
-// https://github.com/jneen/parsimmon/issues/158
-//
-function indentPeek() {
-  return indentStack[indentStack.length - 1];
-}
-
-let indentStack = [0];
-
 let Pythonish = P.createLanguage({
-  // If this were actually Python, "Block" wouldn't be a statement on its own,
-  // but rather "If" and "While" would be statements that used "Block" inside.
+  Program: r =>
+    r.Statement.many().trim(r._).node('Program'),
+
   Statement: r =>
-    P.alt(r.ExpressionStatement, r.Block),
+    P.alt(r.Call, r.Block),
 
-  // Just a simple `foo()` style function call.
-  FunctionCall: () =>
-    P.regexp(/[a-z]+/).skip(P.string('()'))
-      .node('FunctionCall')
-      .desc('a function call'),
+  Call: r =>
+    P.letter.skip(P.string('()')).skip(r.End).node('Call'),
 
-  // To make it a statement we just need a newline afterward.
-  ExpressionStatement: r =>
-    r.FunctionCall.skip(P.string('\n')),
-
-  // The general idea of this is to assume there's "block:" on its own line,
-  // then we capture the whitespace used to indent the first statement of the
-  // block, and require that every other statement has the same exact string of
-  // indentation in front of it.
   Block: r =>
     P.seqObj(
       P.string('block:'),
-      P.string('\n'),
-      ['indent', P.regexp(/[ ]+/)],
-      ['statement', r.Statement]
-    ).chain(args => {
-      // `.chain` is called after a parser succeeds. It returns the next parser
-      // to use for parsing. This allows subsequent parsing to be dependent on
-      // previous text.
-      let {indent, statement} = args;
-      let indentSize = indent.length;
-      let currentSize = indentPeek();
-      // Indentation must be deeper than the current block context. Otherwise
-      // you could indent *less* for a block and it would still work. This is
-      // not how any language I know of works.
-      if (indentSize <= currentSize) {
-        return P.fail('at least ' + currentSize + ' spaces');
-      }
-      indentStack.push(indentSize);
-      return P.string(indent)
-        .then(r.Statement)
-        .many()
-        .map(statements => {
-          indentStack.pop();
-          return [statement].concat(statements);
-        });
-    })
-    .node('Block'),
+      r.End,
+      P.indentMore,
+      ['first', r.Statement],
+      ['rest', P.indentSame.then(r.Statement).many()],
+      P.indentLess
+    ).map(args => {
+      let {first, rest} = args;
+      let statements = [first, ...rest];
+      return {statements};
+    }).node('Block'),
+
+  _: () => P.optWhitespace,
+  NL: () => P.string('\n'),
+  End: r => P.alt(r.NL, P.eof),
 });
 
 ///////////////////////////////////////////////////////////////////////
 
 let text = `\
+z()
 block:
-    a()
-    b()
+  a()
+  b()
+  block:
     c()
-    block:
-      d()
-      e()
-      f()
-    block:
-        g()
-        h()
-        i()
-        j()
+    d()
+e()
 `;
 
 function prettyPrint(x) {
@@ -105,5 +55,5 @@ function prettyPrint(x) {
   console.log(s);
 }
 
-let ast = Pythonish.Block.tryParse(text);
+let ast = Pythonish.Program.tryParse(text);
 prettyPrint(ast);

--- a/examples/python-ish.js
+++ b/examples/python-ish.js
@@ -60,7 +60,7 @@ block:
       block:
         ba()
         bb()
-        bc()
+       bc()
       e()
 f()
 `;

--- a/examples/python-ish.js
+++ b/examples/python-ish.js
@@ -7,20 +7,32 @@ let P = require('..');
 
 ///////////////////////////////////////////////////////////////////////
 
+let sneak = P((str, i, state) => {
+  console.log('\n\n\n----');
+  // console.log(JSON.stringify(str.slice(i)));
+  console.log(str.slice(i));
+  console.log(i, state);
+  return P.makeSuccess(i, null, state);
+});
+
 let Pythonish = P.createLanguage({
   Program: r =>
     r.Statement.many().trim(r._).node('Program'),
 
   Statement: r =>
-    P.alt(r.Call, r.Block),
+    P.alt(r.Call, r.Block).trim(r._),
 
   Call: r =>
-    P.regexp(/[a-z]+/).skip(P.string('()')).skip(r.End).node('Call'),
+    P.regexp(/[a-z]+/)
+      .skip(P.string('()'))
+      .skip(r.Terminator)
+      .node('Call'),
 
   Block: r =>
     P.seqObj(
       P.string('block:'),
-      r.End,
+      r.Terminator,
+      r._,
       r.IndentMore,
       ['first', r.Statement],
       ['rest', r.IndentSame.then(r.Statement).many()],
@@ -35,7 +47,17 @@ let Pythonish = P.createLanguage({
   IndentLess: () => P.indentLess(P.countIndentation),
   IndentSame: () => P.indentSame(P.countIndentation),
 
-  _: () => P.optWhitespace,
+  Comment: r =>
+    P.seq(
+      P.string('#'),
+      P.regexp(/[^\r\n]*/),
+      r.End
+    ),
+  _: r => r.BlankLine.many(),
+  BlankLine: r => r.Spaces0.then(P.alt(r.Comment, r.NL)),
+  Terminator: r =>
+    r.Spaces0.then(P.alt(r.Comment, r.End)),
+  Spaces0: () => P.regexp(/[ \t]*/),
   CR: () => P.string('\r'),
   LF: () => P.string('\n'),
   CRLF: () => P.string('\r\n'),
@@ -45,11 +67,22 @@ let Pythonish = P.createLanguage({
 
 ///////////////////////////////////////////////////////////////////////
 
+let SPACE = ' ';
+
 let text = `\
-z()
-block:
-  a()
-  b()
+
+
+#c0
+
+
+z() #c1'\r\n\
+block:    #   c2\r
+  a() #c3
+
+  b() #       c4
+
+${SPACE}${SPACE}
+${SPACE}${SPACE}# comment
   block:
     c()
     d()
@@ -62,7 +95,7 @@ block:
         bb()
         bc()
       e()
-f()
+f()#c
 `;
 
 function prettyPrint(x) {
@@ -71,5 +104,7 @@ function prettyPrint(x) {
   console.log(s);
 }
 
+console.log(new Date().toTimeString());
+console.log();
 let ast = Pythonish.Program.tryParse(text);
 prettyPrint(ast);

--- a/examples/python-ish.js
+++ b/examples/python-ish.js
@@ -7,14 +7,6 @@ let P = require('..');
 
 ///////////////////////////////////////////////////////////////////////
 
-let sneak = P((str, i, state) => {
-  console.log('\n\n\n----');
-  // console.log(JSON.stringify(str.slice(i)));
-  console.log(str.slice(i));
-  console.log(i, state);
-  return P.makeSuccess(i, null, state);
-});
-
 let Pythonish = P.createLanguage({
   Program: r =>
     r.Statement.many().trim(r._).node('Program'),
@@ -43,26 +35,48 @@ let Pythonish = P.createLanguage({
       return {statements};
     }).node('Block'),
 
+  // Uses standard Parsimmon indentation tracking. This includes either tabs or
+  // spaces, but does not support them mixed. Please note that Python actually
+  // allows mixed tabs and spaces, despite it being a not very good idea.
+  //
+  // https://docs.python.org/3/reference/lexical_analysis.html#indentation
   IndentMore: () => P.indentMore(P.countIndentation),
   IndentLess: () => P.indentLess(P.countIndentation),
   IndentSame: () => P.indentSame(P.countIndentation),
 
+  // Standard Python style comments
   Comment: r =>
     P.seq(
       P.string('#'),
       P.regexp(/[^\r\n]*/),
       r.End
     ),
+
+  // Zero or more blank lines; should be ignore for parsing purposes
   _: r => r.BlankLine.many(),
-  BlankLine: r => r.Spaces0.then(P.alt(r.Comment, r.NL)),
-  Terminator: r =>
-    r.Spaces0.then(P.alt(r.Comment, r.End)),
+
+  // A blank line which should be completely ignored for all parsing purposes
+  BlankLine: r => r.Spaces0.then(P.alt(r.Comment, r.Newline)),
+
+  // A logical "end" of a line can include spaces or a comment before the end
+  Terminator: r => r.Spaces0.then(P.alt(r.Comment, r.End)),
+
+  // Zero or more spaces or tabs
   Spaces0: () => P.regexp(/[ \t]*/),
-  CR: () => P.string('\r'),
-  LF: () => P.string('\n'),
-  CRLF: () => P.string('\r\n'),
-  NL: r => P.alt(r.CRLF, r.LF, r.CR).desc('newline'),
-  End: r => P.alt(r.NL, P.eof),
+
+  // Logical newlines can be:
+  //
+  // - Windows style ("\r\n" aka CRLF)
+  // - UNIX style ("\n" aka LF)
+  // - Mac OS 9 style ("\r" aka CR)
+  //
+  // Realistically, nobody uses Mac OS 9 style any more, but oh well.
+  Newline: () => P.alt(P.string('\r\n'), P.oneOf('\r\n')).desc('newline'),
+
+  // Typically text files *end* each line with a newline, rather than just
+  // separating them, but many files are malformed, so we should support the
+  // "end of file" as a form of newline.
+  End: r => P.alt(r.Newline, P.eof),
 });
 
 ///////////////////////////////////////////////////////////////////////

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -321,7 +321,6 @@ function alt() {
       if (result.status) {
         return result;
       }
-      state = result.state;
     }
     return result;
   });
@@ -458,7 +457,7 @@ _.times = function(min, max) {
     for (var times = 0; times < min; times += 1) {
       result = self._(input, i, state);
       prevResult = mergeReplies(result, prevResult);
-      state = result.state;
+      state = prevResult.state;
       if (result.status) {
         i = result.index;
         accum.push(result.value);
@@ -467,9 +466,9 @@ _.times = function(min, max) {
       }
     }
     for (; times < max; times += 1) {
-      result = self._(input, i);
+      result = self._(input, i, state);
       prevResult = mergeReplies(result, prevResult);
-      state = result.state;
+      state = prevResult.state;
       if (result.status) {
         i = result.index;
         accum.push(result.value);
@@ -618,11 +617,9 @@ function regexp(re, group) {
         var groupMatch = match[group];
         return makeSuccess(i + fullMatch.length, groupMatch, state);
       }
-      return makeFailure(
-        i,
-        'valid match group (0 to ' + match.length + ') in ' + expected,
-        state
-      );
+      var expected2 =
+        'valid match group (0 to ' + match.length + ') in ' + expected;
+      return makeFailure(i, expected2, state);
     }
     return makeFailure(i, expected, state);
   });

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -112,6 +112,16 @@ function unsafeUnion(xs, ys) {
   return keys;
 }
 
+// TODO: Remove this in favor of the ES5 method when we drop ES3 support.
+function arrayIndexOf(array, item) {
+  for (var j = 0; j < array.length; j++) {
+    if (item === array[j]) {
+      return j;
+    }
+  }
+  return -1;
+}
+
 function assertParser(p) {
   if (!isParser(p)) {
     throw new Error('not a parser: ' + p);
@@ -349,7 +359,7 @@ _.parse = function(input, initialState) {
     throw new Error('.parse must be called with a string as its argument');
   }
   if (arguments.length < 2) {
-    initialState = initialStateIndent;
+    initialState = [0];
   }
   var result = this.skip(eof)._(input, 0, initialState);
   if (result.status) {
@@ -369,7 +379,7 @@ _.parse = function(input, initialState) {
 
 _.tryParse = function(str, initialState) {
   if (arguments.length < 2) {
-    initialState = initialStateIndent;
+    initialState = [0];
   }
   var result = this.parse(str, initialState);
   if (result.status) {
@@ -749,8 +759,6 @@ _['fantasy-land/map'] = _.map;
 
 // -*- Base Parsers -*-
 
-var initialStateIndent = [0];
-
 var countIndentation =
   alt(
     regexp(/[ ]*/).desc('at least one space'),
@@ -776,6 +784,9 @@ function indentLess(indentationCounter) {
   return indentationCounter.chain(function(count) {
     return Parsimmon(function(input, i, state) {
       var j = state.length - 1;
+      if (arrayIndexOf(state, count) < 0) {
+        return makeFailure(i, 'consistent indentation', state);
+      }
       if (count < state[j]) {
         return makeSuccess(i, null, state.slice(0, j));
       }
@@ -828,7 +839,6 @@ var whitespace = regexp(/\s+/).desc('whitespace');
 Parsimmon.all = all;
 Parsimmon.alt = alt;
 Parsimmon.any = any;
-Parsimmon.initialStateIndent = initialStateIndent;
 Parsimmon.countIndentation = countIndentation;
 Parsimmon.createLanguage = createLanguage;
 Parsimmon.custom = custom;

--- a/test/core/all.test.js
+++ b/test/core/all.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+suite('all', function() {
+
+  test('should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    test(10)
+      .then(Parsimmon.all)
+      .then(test(10))
+      .tryParse('memes', 10);
+  });
+
+});

--- a/test/core/alt.test.js
+++ b/test/core/alt.test.js
@@ -1,44 +1,69 @@
 'use strict';
 
-test('Parsimmon.alt', function(){
-  var toNode = function(nodeType){
-    return function(value) {
-      return {type: nodeType, value: value};
+suite('Parsimmon.alt', function() {
+
+  test('should work in general', function() {
+    var toNode = function(nodeType){
+      return function(value) {
+        return {type: nodeType, value: value};
+      };
     };
-  };
 
-  var stringParser = Parsimmon.seq(
-    Parsimmon.string('"'),
-    Parsimmon.regexp(/[^"]*/),
-    Parsimmon.string('"')
-  ).map(toNode('string'));
+    var stringParser = Parsimmon.seq(
+      Parsimmon.string('"'),
+      Parsimmon.regexp(/[^"]*/),
+      Parsimmon.string('"')
+    ).map(toNode('string'));
 
-  var identifierParser =
-    Parsimmon.regexp(/[a-zA-Z]*/)
-      .map(toNode('identifier'));
+    var identifierParser =
+      Parsimmon.regexp(/[a-zA-Z]*/)
+        .map(toNode('identifier'));
 
-  var parser = Parsimmon.alt(stringParser, identifierParser);
+    var parser = Parsimmon.alt(stringParser, identifierParser);
 
-  assert.deepEqual(
-    parser.parse('"a string, to be sure"').value,
-    {
-      type: 'string',
-      value: ['"', 'a string, to be sure', '"']
-    }
-  );
+    assert.deepEqual(
+      parser.parse('"a string, to be sure"').value,
+      {
+        type: 'string',
+        value: ['"', 'a string, to be sure', '"']
+      }
+    );
 
-  assert.deepEqual(
-    parser.parse('anIdentifier').value,
-    {
-      type: 'identifier',
-      value: 'anIdentifier'
-    }
-  );
+    assert.deepEqual(
+      parser.parse('anIdentifier').value,
+      {
+        type: 'identifier',
+        value: 'anIdentifier'
+      }
+    );
 
-  assert.throws(function() {
-    Parsimmon.alt('not a parser');
+    assert.throws(function() {
+      Parsimmon.alt('not a parser');
+    });
+
+
+    assert.strictEqual(Parsimmon.alt().parse('').status, false);
   });
 
+  test('should pass state through each parser', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var a = Parsimmon.string('a');
+    var b = Parsimmon.string('b');
+    var c = Parsimmon.string('c');
+    var parser = Parsimmon.alt(
+      test(0).then(inc).then(a).skip(test(1)),
+      test(0).then(inc).then(b).skip(test(1)),
+      test(0).then(inc).then(c).skip(test(1))
+    ).then(test(1));
+    parser.tryParse('c', 0);
+  });
 
-  assert.strictEqual(Parsimmon.alt().parse('').status, false);
 });

--- a/test/core/any.test.js
+++ b/test/core/any.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+suite('any', function() {
+
+  test('should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    test(10)
+      .then(Parsimmon.any)
+      .then(test(10))
+      .tryParse('x', 10);
+  });
+
+});

--- a/test/core/chain.test.js
+++ b/test/core/chain.test.js
@@ -21,4 +21,24 @@ suite('chain', function() {
     assert.ok(!parser.parse('x').status);
   });
 
+  test('should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    function always10() {
+      return 10;
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    Parsimmon.any.chain(function() {
+      return test()
+    })
+    test(0).then(Parsimmon.any.map(always10)).skip(test(0)).tryParse('a', 0);
+    inc.then(Parsimmon.any.map(always10)).skip(test(1)).tryParse('b', 0);
+  });
+
 });

--- a/test/core/constructor.test.js
+++ b/test/core/constructor.test.js
@@ -5,11 +5,11 @@ suite('Parsimmon()', function() {
   test('should work in general', function() {
     var good = 'just a Q';
     var bad = 'all I wanted was a Q';
-    var justQ = Parsimmon(function(str, i) {
+    var justQ = Parsimmon(function(str, i, state) {
       if (str.charAt(i) === 'Q') {
-        return Parsimmon.makeSuccess(i + 1, good);
+        return Parsimmon.makeSuccess(i + 1, good, state);
       } else {
-        return Parsimmon.makeFailure(i, bad);
+        return Parsimmon.makeFailure(i, bad, state);
       }
     });
     var result1 = justQ.parse('Q');
@@ -31,13 +31,14 @@ suite('Parsimmon()', function() {
 
   test('unsafeUnion works on poorly formatted custom parser', function() {
     var p1 = Parsimmon.string('a').or(Parsimmon.string('b'));
-    var p2 = Parsimmon(function(str, i) {
+    var p2 = Parsimmon(function(str, i, state) {
       return {
         status: false,
         index: -1,
         value: null,
         furthest: i,
-        expected: []
+        expected: [],
+        state: state
       };
     });
     var p3 = Parsimmon.alt(p2, p1);

--- a/test/core/custom.test.js
+++ b/test/core/custom.test.js
@@ -4,8 +4,8 @@ suite('Parsimmon.custom', function(){
   test('simple parser definition', function(){
     function customAny() {
       return Parsimmon.custom(function(success){
-        return function(input, i) {
-          return success(i+1, input.charAt(i));
+        return function(input, i, state) {
+          return success(i + 1, input.charAt(i), state);
         };
       });
     }
@@ -21,8 +21,8 @@ suite('Parsimmon.custom', function(){
   test('failing parser', function(){
     function failer() {
       return Parsimmon.custom(function(success, failure){
-        return function(input, i) {
-          return failure(i, 'nothing');
+        return function(input, i, state) {
+          return failure(i, 'nothing', state);
         };
       });
     }
@@ -41,11 +41,12 @@ suite('Parsimmon.custom', function(){
   test('composes with existing parsers', function(){
     function notChar(char) {
       return Parsimmon.custom(function(success, failure) {
-        return function(input, i) {
+        return function(input, i, state) {
           if (input.charCodeAt(i) !== char.charCodeAt(0)) {
-            return success(i+1, input.charAt(i));
+            return success(i + 1, input.charAt(i), state);
           }
-          return failure(i, 'something different than "' + input.charAt(i)) + '"';
+          var message = 'something different than "' + input.charAt(i) + '"';
+          return failure(i, message, state);
         };
       });
     }

--- a/test/core/desc.test.js
+++ b/test/core/desc.test.js
@@ -57,4 +57,20 @@ suite('desc', function() {
       expected: ['the letter y']
     });
   });
+
+  test('should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.any.desc('by any other name?');
+    test(0).then(parser).skip(test(0)).tryParse('a', 0);
+    inc.then(parser).skip(test(1)).tryParse('b', 0);
+  });
+
 });

--- a/test/core/eof.test.js
+++ b/test/core/eof.test.js
@@ -1,11 +1,28 @@
 'use strict';
 
-test('eof', function() {
-  var parser =
-    Parsimmon.optWhitespace
-      .skip(Parsimmon.eof)
-      .or(Parsimmon.all.result('default'));
+suite('eof', function() {
 
-  assert.equal(parser.parse('  ').value, '  ');
-  assert.equal(parser.parse('x').value, 'default');
+  test('should work in general', function() {
+    var parser =
+      Parsimmon.optWhitespace
+        .skip(Parsimmon.eof)
+        .or(Parsimmon.all.result('default'));
+
+    assert.equal(parser.parse('  ').value, '  ');
+    assert.equal(parser.parse('x').value, 'default');
+  });
+
+  test('should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    test(10)
+      .then(Parsimmon.eof)
+      .then(test(10))
+      .tryParse('', 10);
+  });
+
 });

--- a/test/core/fail.test.js
+++ b/test/core/fail.test.js
@@ -59,4 +59,33 @@ suite('fail', function() {
       expected: ['*']
     });
   });
+
+  test('.fail should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var result =
+      test(10)
+        .then(Parsimmon.fail('nice'))
+        ._(0, 'a', 10);
+    assert.strictEqual(result.state, 10);
+  });
+
+  test('.succeed should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var result =
+      test(10)
+        .then(Parsimmon.succeed('anything at all'))
+        ._(0, 'a', 10);
+    assert.strictEqual(result.state, 10);
+  });
+
 });

--- a/test/core/index.test.js
+++ b/test/core/index.test.js
@@ -1,20 +1,37 @@
 'use strict';
 
-test('index', function() {
-  var parser = Parsimmon.regexp(/^[x\n]*/).then(Parsimmon.index);
-  assert.deepEqual(parser.parse('').value, {
-    offset: 0,
-    line: 1,
-    column: 1
+suite('index', function() {
+
+  test('should work in general', function() {
+    var parser = Parsimmon.regexp(/^[x\n]*/).then(Parsimmon.index);
+    assert.deepEqual(parser.parse('').value, {
+      offset: 0,
+      line: 1,
+      column: 1
+    });
+    assert.deepEqual(parser.parse('xx').value, {
+      offset: 2,
+      line: 1,
+      column: 3
+    });
+    assert.deepEqual(parser.parse('xx\nxx').value, {
+      offset: 5,
+      line: 2,
+      column: 3
+    });
   });
-  assert.deepEqual(parser.parse('xx').value, {
-    offset: 2,
-    line: 1,
-    column: 3
+
+  test('should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    test(10)
+      .then(Parsimmon.index)
+      .then(test(10))
+      .tryParse('', 10);
   });
-  assert.deepEqual(parser.parse('xx\nxx').value, {
-    offset: 5,
-    line: 2,
-    column: 3
-  });
+
 });

--- a/test/core/lookahead.test.js
+++ b/test/core/lookahead.test.js
@@ -61,4 +61,23 @@ suite('Parsimmon.lookahead', function() {
     assert.throws(function() { Parsimmon.lookahead(12); });
   });
 
+  test('should pass state through unchanged', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.lookahead(Parsimmon.regexp(/a/));
+    test(0)
+      .then(inc)
+      .then(parser)
+      .skip(test(1))
+      .then(Parsimmon.string('a'))
+      .tryParse('a', 0);
+  });
+
 });

--- a/test/core/makeFailure.test.js
+++ b/test/core/makeFailure.test.js
@@ -3,12 +3,13 @@
 test('Parsimmon.makeFailure', function() {
   var furthest = 4444;
   var expected = 'waiting in the clock tower';
-  var result = Parsimmon.makeFailure(furthest, expected);
+  var result = Parsimmon.makeFailure(furthest, expected, undefined);
   assert.deepEqual(result, {
     status: false,
     index: -1,
     value: null,
     furthest: furthest,
-    expected: [expected]
+    expected: [expected],
+    state: undefined
   });
 });

--- a/test/core/makeSuccess.test.js
+++ b/test/core/makeSuccess.test.js
@@ -3,12 +3,13 @@
 test('Parsimmon.makeSuccess', function() {
   var index = 11;
   var value = 'a lucky number';
-  var result = Parsimmon.makeSuccess(index, value);
+  var result = Parsimmon.makeSuccess(index, value, 'state');
   assert.deepEqual(result, {
     status: true,
     index: index,
     value: value,
     furthest: -1,
-    expected: []
+    expected: [],
+    state: 'state'
   });
 });

--- a/test/core/many.test.js
+++ b/test/core/many.test.js
@@ -18,4 +18,18 @@ suite('many', function() {
     assert.equal(parser.parse('xxxxxy').value, 'y');
   });
 
+  test('should pass state through each parser', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.any.then(inc).many().then(test(4));
+    parser.tryParse('abcd', 0);
+  });
+
 });

--- a/test/core/map.test.js
+++ b/test/core/map.test.js
@@ -23,4 +23,21 @@ suite('map', function() {
     });
   });
 
+  test('should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    function always10() {
+      return 10;
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    test(0).then(Parsimmon.any.map(always10)).skip(test(0)).tryParse('a', 0);
+    inc.then(Parsimmon.any.map(always10)).skip(test(1)).tryParse('b', 0);
+  });
+
 });

--- a/test/core/notFollowedBy.test.js
+++ b/test/core/notFollowedBy.test.js
@@ -33,4 +33,23 @@ suite('Parsimmon.notFollowedBy', function() {
     assert.deepEqual(answer.value, ['abc', 'd']);
   });
 
+  test('should pass state through unchanged', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.notFollowedBy(Parsimmon.regexp(/a/));
+    test(0)
+      .then(inc)
+      .then(parser)
+      .skip(test(1))
+      .then(Parsimmon.string('b'))
+      .tryParse('b', 0);
+  });
+
 });

--- a/test/core/regexp.test.js
+++ b/test/core/regexp.test.js
@@ -50,4 +50,19 @@ suite('Parsimmon.regexp', function() {
     assert.strictEqual(parser3.parse('a1').status, false);
   });
 
+  test('should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.regexp(/./);
+    test(0).then(parser).skip(test(0)).tryParse('a', 0);
+    inc.then(parser).skip(test(1)).tryParse('b', 0);
+  });
+
 });

--- a/test/core/seq.test.js
+++ b/test/core/seq.test.js
@@ -1,7 +1,9 @@
 'use strict';
 
-test('Parsimmon.seq', function() {
-  var parser =
+suite('Parsimmon.seq', function() {
+
+  test('should work in general', function() {
+    var parser =
       Parsimmon.seq(
         Parsimmon.string('('),
         Parsimmon.regexp(/[^)]/).many().map(function(xs) {
@@ -10,39 +12,58 @@ test('Parsimmon.seq', function() {
         Parsimmon.string(')')
       );
 
-  assert.deepEqual(
+    assert.deepEqual(
       parser.parse('(string between parens)').value,
       ['(', 'string between parens', ')']
     );
 
-  assert.deepEqual(
+    assert.deepEqual(
       parser.parse('(string'),
-    {
-      status: false,
-      index: {
-        offset: 7,
-        line: 1,
-        column: 8
-      },
-      expected: ['\')\'', '/[^)]/']
-    }
+      {
+        status: false,
+        index: {
+          offset: 7,
+          line: 1,
+          column: 8
+        },
+        expected: ['\')\'', '/[^)]/']
+      }
     );
 
-  assert.deepEqual(
+    assert.deepEqual(
       parser.parse('starts wrong (string between parens)'),
-    {
-      status: false,
-      index: {
-        offset: 0,
-        line: 1,
-        column: 1
-      },
-      expected: ['\'(\'']
-    }
+      {
+        status: false,
+        index: {
+          offset: 0,
+          line: 1,
+          column: 1
+        },
+        expected: ['\'(\'']
+      }
     );
 
-  assert.throws(function() {
-    Parsimmon.seq('not a parser');
+    assert.throws(function() {
+      Parsimmon.seq('not a parser');
+    });
   });
-});
 
+  test('should pass state through each parser', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.seq(
+      test(0).then(inc).then(Parsimmon.any).skip(test(1)),
+      test(1).then(inc).then(Parsimmon.any).skip(test(2)),
+      test(2).then(inc).then(Parsimmon.any).skip(test(3))
+    ).then(test(3));
+    parser.tryParse('abc', 0);
+  });
+
+});

--- a/test/core/seqObj.test.js
+++ b/test/core/seqObj.test.js
@@ -76,4 +76,22 @@ suite('Parsimmon.seqObj', function() {
     });
   });
 
+  test('should pass state through each parser', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.seqObj(
+      test(0).then(inc).then(Parsimmon.any).skip(test(1)),
+      ['result', test(1).then(inc).then(Parsimmon.any).skip(test(2))],
+      test(2).then(inc).then(Parsimmon.any).skip(test(3))
+    ).then(test(3));
+    parser.tryParse('abc', 0);
+  });
+
 });

--- a/test/core/string.test.js
+++ b/test/core/string.test.js
@@ -1,26 +1,45 @@
 'use strict';
 
-test('Parsimmon.string', function() {
-  var parser = Parsimmon.string('x');
-  var res = parser.parse('x');
-  assert.ok(res.status);
-  assert.equal(res.value, 'x');
+suite('Parsimmon.string', function() {
 
-  res = parser.parse('y');
-  assert.deepEqual(res, {
-    status: false,
-    index: {
-      offset: 0,
-      line: 1,
-      column: 1
-    },
-    expected: ['\'x\'']
+  test('should work in general', function() {
+    var parser = Parsimmon.string('x');
+    var res = parser.parse('x');
+    assert.ok(res.status);
+    assert.equal(res.value, 'x');
+
+    res = parser.parse('y');
+    assert.deepEqual(res, {
+      status: false,
+      index: {
+        offset: 0,
+        line: 1,
+        column: 1
+      },
+      expected: ['\'x\'']
+    });
+
+    assert.equal(
+      'expected \'x\' at line 1 column 1, got \'y\'',
+      Parsimmon.formatError('y', res)
+    );
+
+    assert.throws(function() { Parsimmon.string(34); });
   });
 
-  assert.equal(
-    'expected \'x\' at line 1 column 1, got \'y\'',
-    Parsimmon.formatError('y', res)
-  );
+  test('should pass state through', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.string('a');
+    test(0).then(parser).skip(test(0)).tryParse('a', 0);
+    inc.then(parser).skip(test(1)).tryParse('a', 0);
+  });
 
-  assert.throws(function() { Parsimmon.string(34); });
 });

--- a/test/core/takeWhile.test.js
+++ b/test/core/takeWhile.test.js
@@ -1,15 +1,40 @@
 'use strict';
 
-test('takeWhile', function() {
-  var parser =
-    Parsimmon.takeWhile(function(ch) {
-      return ch !== '.';
-    }).skip(Parsimmon.all);
-  assert.equal(parser.parse('abc').value, 'abc');
-  assert.equal(parser.parse('abc.').value, 'abc');
-  assert.equal(parser.parse('.').value, '');
-  assert.equal(parser.parse('').value, '');
-  assert.throws(function() {
-    Parsimmon.takeWhile('not a function');
+suite('takeWhile', function() {
+
+  test('should work in general', function() {
+    var parser =
+      Parsimmon.takeWhile(function(ch) {
+        return ch !== '.';
+      }).skip(Parsimmon.all);
+    assert.equal(parser.parse('abc').value, 'abc');
+    assert.equal(parser.parse('abc.').value, 'abc');
+    assert.equal(parser.parse('.').value, '');
+    assert.equal(parser.parse('').value, '');
+    assert.throws(function() {
+      Parsimmon.takeWhile('not a function');
+    });
   });
+
+  test('should pass state through unchanged', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.takeWhile(function(str) {
+      return str < 'c';
+    });
+    test(0)
+      .then(inc)
+      .then(parser)
+      .skip(test(1))
+      .then(Parsimmon.string('c'))
+      .tryParse('abc', 0);
+  });
+
 });

--- a/test/core/test.test.js
+++ b/test/core/test.test.js
@@ -1,8 +1,32 @@
 'use strict';
 
-test('test', function() {
-  var parser = Parsimmon.test(function(ch) { return ch !== '.'; });
-  assert.equal(parser.parse('x').value, 'x');
-  assert.equal(parser.parse('.').status, false);
-  assert.throws(function() { Parsimmon.test('not a function'); });
+suite('test', function() {
+
+  test('it works in general', function() {
+    var parser = Parsimmon.test(function(ch) { return ch !== '.'; });
+    assert.equal(parser.parse('x').value, 'x');
+    assert.equal(parser.parse('.').status, false);
+    assert.throws(function() { Parsimmon.test('not a function'); });
+  });
+
+  test('should pass state through unchanged', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.test(function(str) {
+      return str === 'b';
+    });
+    test(0)
+      .then(inc)
+      .then(parser)
+      .skip(test(1))
+      .tryParse('b', 0);
+  });
+
 });

--- a/test/core/times.test.js
+++ b/test/core/times.test.js
@@ -72,4 +72,22 @@ suite('times', function() {
     });
   });
 
+  test('should pass state through each parser', function() {
+    function test(n) {
+      return Parsimmon(function(input, i, state) {
+        assert.strictEqual(state, n);
+        return Parsimmon.makeSuccess(i, undefined, state);
+      });
+    }
+    var inc = Parsimmon(function(input, i, state) {
+      return Parsimmon.makeSuccess(i, null, state + 1);
+    });
+    var parser = Parsimmon.any.then(inc).times(2, 6);
+    parser.then(test(2)).tryParse('ab', 0);
+    parser.then(test(3)).tryParse('abc', 0);
+    parser.then(test(4)).tryParse('abcd', 0);
+    parser.then(test(5)).tryParse('abcde', 0);
+    parser.then(test(6)).tryParse('abcdef', 0);
+  });
+
 });


### PR DESCRIPTION
## Summary

3 core functions:

- Parsimmon.indentMore
- Parsimmon.indentLess
- Parsimmon.indentSame

These consume 0 or more space characters, and update the parser state as necessary. Now all parsers take `(string, index, state)` instead of just `(string, index)`, and `.parse` and `.tryParse` take an optional second parameter for the initial state, which defaults to `[0]`, the state format expected  by the `Parsimmon.indent*` functions.

If you check out `examples/python-ish.js` in this branch you should see it's fairly straightforward to parse a space-indented language with these parsers and internal changes. But it's not extensible at all, so if your indentation is more complicated then you'll have to hook directly into state tracking yourself.

## Concerns

State currently may not be correctly piped through all the combinator functions. This would require a lot of extra testing to validate. The good part is it wasn't much work to make the test suite pass, and I ran this version of the library against three of my programming languages, including Squiggle, and it appeared to function correctly still.

JavaScript is filled with mutable data structures, which are a poor fit for state tracking, so exposing the internals is a bit dangerous. This state API will need to come with copious warnings.

## Maybe?

- [ ] Make the `Parsimmon.indent*` things into functions that take a parser?
- [ ] Expose `countSpaces`?

# TODO: Do not merge into master

- [x] Documentation
- [x] Changelog
- [x] Check out what ["inconsistent dedent"](https://docs.python.org/3/reference/lexical_analysis.html) means from Python
- [ ] Add comments, blank lines to `python-ish.js`
- [ ] Bring test coverage back to 100%
- [ ] BREAKING CHANGE
