### PR TITLE
Make fallback be compatible with many()

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -541,7 +541,16 @@ _.desc = function(expected) {
 };
 
 _.fallback = function(result) {
-  return this.or(succeed(result));
+  var isCalled = {};
+  var self = this;
+  return Parsimmon(function(input, i) {
+    var reply = self._(input, i);
+    if (reply.status || isCalled[i]) {
+      return reply;
+    }
+    isCalled[i] = true;
+    return succeed(result)._(input, i);
+  });
 };
 
 _.ap = function(other) {

--- a/test/core/fallback.test.js
+++ b/test/core/fallback.test.js
@@ -2,10 +2,21 @@
 
 suite('fallback', function() {
 
-  test('allows fallback result if no match is found', function() {
+  test('returns same result as original when match is found', function() {
     var parser = Parsimmon.string('a').fallback('nothing');
     assert.deepEqual(parser.parse('a').value, 'a');
+  });
+
+  test('allows fallback result if no match is found', function() {
+    var parser = Parsimmon.string('a').fallback('nothing');
     assert.deepEqual(parser.parse('').value, 'nothing');
   });
 
+  test('will work with many() method', function() {
+    var parser = Parsimmon.alt(
+      Parsimmon.string('b').fallback('nothing'),
+      Parsimmon.string('a')
+    ).many();
+    assert.deepEqual(parser.parse('bbba').value, ['b', 'b', 'b', 'nothing', 'a', 'nothing']);
+  });
 });


### PR DESCRIPTION
Because `P.succeed` does not consume input, it cannot use with `many()`. It causes infinite loops.
So I added a counter to `fallback` and wraps it with new parser. Now `fallback` will be only called once per same `i`.