### PR TITLE
Many parser should not handle infinite loop

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -396,14 +396,16 @@ _.then = function(next) {
 
 _.many = function() {
   var self = this;
-
   return Parsimmon(function(input, i) {
     var accum = [];
     var result = undefined;
-
+    
     for (;;) {
       result = mergeReplies(self._(input, i), result);
       if (result.status) {
+        if (i === result.index) {
+          return makeFailure(i, 'Infinite loop has been detected in many() parser');
+        }
         i = result.index;
         accum.push(result.value);
       } else {

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -399,7 +399,7 @@ _.many = function() {
   return Parsimmon(function(input, i) {
     var accum = [];
     var result = undefined;
-    
+
     for (;;) {
       result = mergeReplies(self._(input, i), result);
       if (result.status) {

--- a/test/core/many.test.js
+++ b/test/core/many.test.js
@@ -18,4 +18,9 @@ suite('many', function() {
     assert.equal(parser.parse('xxxxxy').value, 'y');
   });
 
+  test('can process infinite loop', function() {
+    var parser = Parsimmon.string('').many();
+    assert.equal(parser.parse('y').status, false);
+  });
+
 });

--- a/test/core/many.test.js
+++ b/test/core/many.test.js
@@ -18,7 +18,7 @@ suite('many', function() {
     assert.equal(parser.parse('xxxxxy').value, 'y');
   });
 
-  test('can process infinite loop', function() {
+  test('aborts on 0-character parse', function() {
     var parser = Parsimmon.string('').many();
     assert.equal(parser.parse('y').status, false);
   });


### PR DESCRIPTION
Related to #197 

This changes contains runtime detection of infinite loop. If current parsing position is exact same as each parser's result, it should be infinite loop.