### PR TITLE
Fix issue where entire (very long) input is passed to bitSeq.

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -129,11 +129,12 @@ function bitSeq(alignments) {
   }
 
   return new Parsimmon(function(input, i) {
-    if (bytes + i > input.length) {
+    var newPos = bytes + i;
+    if (newPos > input.length) {
       return makeFailure(i, bytes.toString() + " bytes");
     }
     return makeSuccess(
-      i + bytes,
+      newPos,
       reduce(
         function(acc, bits) {
           var state = consumeBitsFromBuffer(bits, acc.buf);
@@ -142,7 +143,7 @@ function bitSeq(alignments) {
             buf: state.buf
           };
         },
-        { coll: [], buf: input },
+        { coll: [], buf: input.slice(i, newPos) },
         alignments
       ).coll
     );

--- a/test/core/bitSeq.test.js
+++ b/test/core/bitSeq.test.js
@@ -42,4 +42,15 @@ describe("bitSeq", function() {
       }, /buffer global/i);
     });
   });
+
+  context("We are bitSeq'ing not at the beginning.", function() {
+    it("Should still work.", function() {
+      var b = Buffer.from([0x10, 0xff, 0xff]);
+      var p = Parsimmon.seqObj(Parsimmon.any, [
+        "data",
+        Parsimmon.Binary.bitSeq([3, 5, 5, 3])
+      ]);
+      assert.deepEqual(p.parse(b).value.data, [7, 31, 31, 7]);
+    });
+  });
 });


### PR DESCRIPTION
So I need help writing a test that actually creates the problem I have fixed.  In the binary parser I have constructed, when the parser runs, I am getting the entire input to bitSeq, when it's supposed to just operate on a slice of the input (when embedded as part of a large parsing context).  I have fixed this issue, but I cannot seem to replicate it in a small test to prove it's an issue.

Can someone help me construct a proper test that will fail without this change?