### PR TITLE
Add argv parsing example

### DIFF
--- a/examples/argv.js
+++ b/examples/argv.js
@@ -1,0 +1,100 @@
+"use strict";
+
+// Run me with Node to see my output!
+// $ node examples/argv.js foo -x
+// $ node examples/argv.js -x=1 bar
+// $ node examples/argv.js --some --thing=x
+
+let util = require("util");
+let P = require("..");
+
+let CLI = P.createLanguage({
+  expression: function(r) {
+    // whitespace-separated words, strings and options
+    return P.alt(r.word, r.string, r.option)
+      .sepBy(P.whitespace)
+      .trim(P.optWhitespace);
+  },
+
+  option: function(r) {
+    // one of possible quotes, then sequence of anything except that quote (unless escaped), then the same quote
+    return P.seq(
+      P.alt(P.string("-").then(P.regex(/[a-z]/)), P.string("--").then(r.word)),
+      P.alt(P.string("=").then(r.word), P.of(true))
+    );
+  },
+
+  word: function() {
+    // 1 char of anything except forbidden symbols and dash, then 0+ chars of anything except forbidden symbols
+    return P.regex(/[^-=\s"'][^=\s"']*/);
+  },
+
+  string: function() {
+    // one of possible quotes, then sequence of anything except that quote (unless escaped), then the same quote
+    return P.oneOf(`"'`).chain(function(q) {
+      return P.alt(
+        P.regex(new RegExp(`[^\\\\${q}]+`)),
+        P.string(`\\`).then(P.any)
+      )
+        .many()
+        .tie()
+        .skip(P.string(q));
+    });
+  }
+});
+
+let args = process.argv.slice(2).join(" ");
+
+function prettyPrint(x) {
+  let opts = { depth: null, colors: "auto" };
+  let s = util.inspect(x, opts);
+  console.log(s);
+}
+
+let ast = CLI.expression.tryParse(args);
+prettyPrint(ast);
+
+/*
+#### Intentionally not supported
+
+1) Space-delemited flag values
+
+```
+$ command --foo FOO
+as
+$ command --foo=FOO
+```
+
+because it's non-context-free. It's impossible to tell if `FOO` related to `command` or `--foo`
+without an intimate knowledge of exact flags (which couples parser and application).
+
+2) Flag joining
+
+```
+$ command -fgh
+as
+$ command -f -g -h
+```
+
+I just don't like this style. It's easy to confuse `-any` and `--any`.
+
+#### Nesting
+
+Commands can be nested but the exact meaning of WORD is up to an application. For example:
+
+```
+$ git pull origin master
+```
+
+can be seen as one of:
+
+```
+$ git arg1 arg2 arg3
+or
+$ git (pull arg1 arg2) -- (you want this one)
+or
+$ git (pull (origin arg))
+```
+
+So the parser does what it does.
+*/

--- a/examples/argv.js
+++ b/examples/argv.js
@@ -33,8 +33,10 @@ let CLI = P.createLanguage({
     // one of possible quotes, then sequence of anything except that quote (unless escaped), then the same quote
     return P.oneOf(`"'`).chain(function(q) {
       return P.alt(
-        P.noneOf(`\\${q}`).atLeast(1).tie(), // everything but quote and escape sign
-        P.string(`\\`).then(P.any)           // escape sequence like \"
+        P.noneOf(`\\${q}`)
+          .atLeast(1)
+          .tie(), // everything but quote and escape sign
+        P.string(`\\`).then(P.any) // escape sequence like \"
       )
         .many()
         .tie()
@@ -55,26 +57,46 @@ let ast = CLI.expression.tryParse(expression);
 prettyPrint(ast);
 
 /*
-Intentionally not supported:
+ #### Intentionally not supported
 
-  1) Space-delemited flag values
+ 1) Space-delemited flag values
 
-  ```
-  $ command --foo FOO
-  as
-  $ command --foo=FOO
-  ```
+ ```
+ $ command --foo FOO
+ as	+  as
+ $ command --foo=FOO
+ ```
 
-  because it's non-context-free. It's impossible to tell if `FOO` related to `command` or `--foo`
-  without an intimate knowledge of exact flags (which couples parser and application).
+ because it's non-context-free. It's impossible to tell if `FOO` related to `command` or `--foo`
+ without an intimate knowledge of exact flags (which couples parser and application).
 
-  2) Flag joining
+ 2) Flag joining
 
-  ```
-  $ command -fgh
-  as
-  $ command -f -g -h
-  ```
+ ```
+ $ command -fgh
+ as
+ $ command -f -g -h
+ ```
 
-  I just don't like this style. It's easy to confuse `-any` and `--any`.
+ I just don't like this style. It's easy to confuse `-any` and `--any`.
+
+ #### Nesting
+
+ Commands can be nested but the exact meaning of WORD is up to an application. For example:
+
+ ```
+ $ git pull origin master
+ ```
+
+ can be seen as one of:
+
+ ```
+ $ git arg1 arg2 arg3
+ or
+ $ git (pull arg1 arg2) -- you want this one
+ or
+ $ git (pull (origin arg))
+ ```
+
+ So the parser does what it does.
 */


### PR DESCRIPTION
Hey guys, can I suggest an example of argv (CLI) parsing? 

1\) NodeJS provides `process.argv` obviously but it's quite low-level. For example, I'd like to have

```
$ node argv.js foo -f bar
```

parsed as

```
["foo", ["f", true], "bar"]
```

instead of

```
["foo", "-f", "bar"]
```

You may also want to parse `argv`-like strings in Browser (to highlight code or whatever).

2\) Moreover, this example showcases a parsing of quoted strings:

```js
string: function() {
  // one of possible quotes, then sequence of anything except that quote (unless escaped), then the same quote
  return P.oneOf(`"'`).chain(function(q) {
    return P.alt(
      P.regex(new RegExp(`[^\\\\${q}]+`)),
      P.string(`\\`).then(P.any)
    )
      .many()
      .tie()
      .skip(P.string(q));
  });
}
```

with escape support, which no other example currently does (except `json.js` but not 100% close).

Any remarks are welcome. I followed the style of other examples – it passes `$ npm run lint`.