### PR TITLE
Prefix keys in seqObj's seenKeys to avoid collisions

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -167,7 +167,7 @@ function bitSeqObj(namedAlignments) {
       }
       assertString(pair[0]);
       assertNumber(pair[1]);
-      if (seenKeys[pair[0]]) {
+      if (Object.prototype.hasOwnProperty.call(seenKeys, pair[0])) {
         throw new Error("duplicate key in bitSeqObj: " + pair[0]);
       }
       seenKeys[pair[0]] = true;

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -455,10 +455,10 @@ function seqObj() {
         p.length === 2 && typeof p[0] === "string" && isParser(p[1]);
       if (isWellFormed) {
         var key = p[0];
-        if (seenKeys[key]) {
+        if (seenKeys["$" + key]) {
           throw new Error("seqObj: duplicate key " + key);
         }
-        seenKeys[key] = true;
+        seenKeys["$" + key] = true;
         totalKeys++;
         continue;
       }

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -455,10 +455,10 @@ function seqObj() {
         p.length === 2 && typeof p[0] === "string" && isParser(p[1]);
       if (isWellFormed) {
         var key = p[0];
-        if (seenKeys["$" + key]) {
+        if (Object.prototype.hasOwnProperty.call(seenKeys, key)) {
           throw new Error("seqObj: duplicate key " + key);
         }
-        seenKeys["$" + key] = true;
+        seenKeys[key] = true;
         totalKeys++;
         continue;
       }

--- a/test/core/bitSeqObj.test.js
+++ b/test/core/bitSeqObj.test.js
@@ -85,4 +85,10 @@ describe("bitSeqObj", function() {
       }, /buffer global/i);
     });
   });
+
+  test("accepts 'constructor' as a key", function() {
+    var b = Buffer.from([0xff]);
+    var p = Parsimmon.Binary.bitSeqObj([["constructor", 8]]);
+    assert.deepEqual(p.parse(b).value, { constructor: 255 });
+  });
 });

--- a/test/core/seqObj.test.js
+++ b/test/core/seqObj.test.js
@@ -73,4 +73,12 @@ suite("Parsimmon.seqObj", function() {
       Parsimmon.seqObj(0);
     });
   });
+
+  test("accepts 'constructor' as a key", function() {
+    var parser = Parsimmon.seqObj(["constructor", Parsimmon.of(1)]);
+    var result = parser.tryParse("");
+    assert.deepStrictEqual(result, {
+      constructor: 1
+    });
+  });
 });


### PR DESCRIPTION
Otherwise, seqObj will fail for the keys in `Object.getOwnPropertyNames(Object.prototype)`, the most likely collision being "constructor".

An alternate implementation strategy is `Object.create(null)`, but it's not supported on IE <9, and is not possible to polyfill.