### PR TITLE
travis: Cache npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ node_js:
   - "7"
   - "6"
 after_success: npm run coverage
+cache: npm


### PR DESCRIPTION
Fixes #223.

Per instructions: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#caching-with-npm

The `cache`, `install`, and `script` sections are automatically determined by Travis. The only thing I didn't do is manually selecting a version of `npm` to install, but I figured that it wasn't super necessary.