### PR TITLE
docs: simplify docs for parser.result

### DIFF
--- a/API.md
+++ b/API.md
@@ -981,7 +981,7 @@ The same caveat for contramap above applies to promap.
 
 ## parser.result(value)
 
-Returns a new parser with the same behavior, but which yields `value`. Equivalent to `parser.map(function(x) { return x; }.bind(value))`.
+Returns a new parser with the same behavior, but which yields `value`. Equivalent to `parser.map(() => value)`.
 
 ## parser.fallback(value)
 


### PR DESCRIPTION
Implementation of `Parsimmon.result`:
https://github.com/jneen/parsimmon/blob/f71a73882383013628cdd87017ae1617c765cf93/src/parsimmon.js#L959-L963