### PR TITLE
Add a memoize to makeLineColumnIndex for large input scenarios

### DIFF
--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -355,6 +355,8 @@ function mergeReplies(result, last) {
   };
 }
 
+// Hold a simple memoize for the last value
+var lastLineColumnIndex = {};
 function makeLineColumnIndex(input, i) {
   if (isBuffer(input)) {
     return {
@@ -363,16 +365,25 @@ function makeLineColumnIndex(input, i) {
       column: -1
     };
   }
+  // if we are calling this function with the same arguments as last time
+  // return the memoized value to prevent expensive processing below
+  if (lastLineColumnIndex.input === input && lastLineColumnIndex.i === i) {
+    return lastLineColumnIndex.value;
+  }
   var lines = input.slice(0, i).split("\n");
   // Note that unlike the character offset, the line and column offsets are
   // 1-based.
   var lineWeAreUpTo = lines.length;
   var columnWeAreUpTo = lines[lines.length - 1].length + 1;
-  return {
+  var value = {
     offset: i,
     line: lineWeAreUpTo,
     column: columnWeAreUpTo
   };
+  lastLineColumnIndex.input = input;
+  lastLineColumnIndex.i = i;
+  lastLineColumnIndex.value = value;
+  return value;
 }
 
 // Returns the sorted set union of two arrays of strings


### PR DESCRIPTION
I had an example of parsing a 231K file. This was taking around 56 seconds. I did profiling and found that it was calling `makeLineColumnIndex` a lot, it accounted for ~40 seconds of the time spent. While running through debugging, I found that this function was being called multiple times with the same arguments, in sequence.

I added a simple memoize with a cache of 1 (the last argument set) and the parse time went down to 13 seconds.

So I am not familiar with the internals of `parsimmon` so I can't say why the same function is being with the same arguments (maybe it is my parser implementation). The use case I have is parsing through this file, and I want to keep a lot of marks/index values because later I want to use this as an AST to edit the file quickly and precisely.