### PR TITLE
Dotall regex support

### DIFF
--- a/API.md
+++ b/API.md
@@ -232,7 +232,7 @@ Parsimmon.test(function(c) {
 
 ## Parsimmon.regexp(regexp)
 
-Returns a parser that looks for a match to the regexp and yields the entire text matched. The regexp will always match starting at the current parse location. The regexp may only use the following flags: `imu`. Any other flag will result in an error being thrown.
+Returns a parser that looks for a match to the regexp and yields the entire text matched. The regexp will always match starting at the current parse location. The regexp may only use the following flags: `imus`. Any other flag will result in an error being thrown.
 
 ## Parsimmon.regexp(regexp, group)
 

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -459,10 +459,10 @@ function assertRegexp(x) {
   var f = flags(x);
   for (var i = 0; i < f.length; i++) {
     var c = f.charAt(i);
-    // Only allow regexp flags [imu] for now, since [g] and [y] specifically
+    // Only allow regexp flags [imus] for now, since [g] and [y] specifically
     // mess up Parsimmon. If more non-stateful regexp flags are added in the
     // future, this will need to be revisited.
-    if (c !== "i" && c !== "m" && c !== "u") {
+    if (c !== "i" && c !== "m" && c !== "u" && c !== "s") {
       throw new Error('unsupported regexp flag "' + c + '": ' + x);
     }
   }

--- a/test/core/regexp.test.js
+++ b/test/core/regexp.test.js
@@ -56,4 +56,10 @@ describe("Parsimmon.regexp", function() {
       index: { column: 1, line: 1, offset: 0 }
     });
   });
+
+  it("support dotAll regex flag (/s)", function() {
+    var parser = Parsimmon.regexp(/"""(.*)"""/s, 1);
+    var multilineString = '"""line1\nline2"""';
+    assert.equal(parser.parse(multilineString).value, "line1\nline2");
+  });
 });

--- a/test/core/regexp.test.js
+++ b/test/core/regexp.test.js
@@ -56,10 +56,4 @@ describe("Parsimmon.regexp", function() {
       index: { column: 1, line: 1, offset: 0 }
     });
   });
-
-  it("support dotAll regex flag (/s)", function() {
-    var parser = Parsimmon.regexp(/"""(.*)"""/s, 1);
-    var multilineString = '"""line1\nline2"""';
-    assert.equal(parser.parse(multilineString).value, "line1\nline2");
-  });
 });


### PR DESCRIPTION
This PR brings `s` (dotAll) flag support for regular expressions from ES2018.
More details and brief discussion is here: https://github.com/jneen/parsimmon/issues/300