### PR TITLE
workaround for broken Edge versions 15-18

### DIFF
--- a/API.md
+++ b/API.md
@@ -34,7 +34,6 @@
   - [Parsimmon.lazy(fn)](#parsimmonlazyfn)
   - [Parsimmon.lazy(description, fn)](#parsimmonlazydescription-fn)
   - [Parsimmon.fail(message)](#parsimmonfailmessage)
-  - [Parsimmon.flags(regexp)](#parsimmonflagsregexp)
   - [Parsimmon.letter](#parsimmonletter)
   - [Parsimmon.letters](#parsimmonletters)
   - [Parsimmon.digit](#parsimmondigit)
@@ -377,10 +376,6 @@ Equivalent to `Parsimmon.lazy(f).desc(description)`.
 ## Parsimmon.fail(message)
 
 Returns a failing parser with the given message.
-
-## Parsimmon.flags(regexp)
-
-Returns the flags set on the given `RegExp` object. Polyfilled for old browsers.
 
 ## Parsimmon.letter
 

--- a/API.md
+++ b/API.md
@@ -34,6 +34,7 @@
   - [Parsimmon.lazy(fn)](#parsimmonlazyfn)
   - [Parsimmon.lazy(description, fn)](#parsimmonlazydescription-fn)
   - [Parsimmon.fail(message)](#parsimmonfailmessage)
+  - [Parsimmon.flags(regexp)](#parsimmonflagsregexp)
   - [Parsimmon.letter](#parsimmonletter)
   - [Parsimmon.letters](#parsimmonletters)
   - [Parsimmon.digit](#parsimmondigit)
@@ -376,6 +377,10 @@ Equivalent to `Parsimmon.lazy(f).desc(description)`.
 ## Parsimmon.fail(message)
 
 Returns a failing parser with the given message.
+
+## Parsimmon.flags(regexp)
+
+Returns the flags set on the given `RegExp` object. Polyfilled for old browsers.
 
 ## Parsimmon.letter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## version 1.16.0 (2020-08-25)
 
-- Fixes `flags(regexp)` to work in older browsers (Edge versions 15-18), which fixes crashes on startup in those old clients
+- Fixes a crash in MS Edge 15-18 when using `Parsimmon.regexp` (thanks @ekilah)
 
 ## version 1.15.0 (2020-07-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## version 1.16.0 (2020-08-25)
+
+- Adds `Parsimmon.flags(regexp)` export
+- Fixes `Parsimmon.flags(regexp)` to work in older browsers (Edge versions 15-18)
+
 ## version 1.15.0 (2020-07-27)
 
 - Adds support for the `s` (`dotAll`) flag in `Parsimmon.regexp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## version 1.16.0 (2020-08-25)
 
-- Adds `Parsimmon.flags(regexp)` export
-- Fixes `Parsimmon.flags(regexp)` to work in older browsers (Edge versions 15-18)
+- Fixes `flags(regexp)` to work in older browsers (Edge versions 15-18), which fixes crashes on startup in those old clients
 
 ## version 1.15.0 (2020-07-27)
 

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -1365,7 +1365,6 @@ Parsimmon.empty = empty;
 Parsimmon.end = end;
 Parsimmon.eof = eof;
 Parsimmon.fail = fail;
-Parsimmon.flags = flags;
 Parsimmon.formatError = formatError;
 Parsimmon.index = index;
 Parsimmon.isParser = isParser;

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -694,13 +694,17 @@ function formatError(input, error) {
 }
 
 function flags(re) {
-  var s = "" + re;
-  var fs = s.slice(s.lastIndexOf("/") + 1);
-  if (fs === "undefined") {
-    // MS Edge v15-18 workaround
-    return ""
+  if (re.flags !== undefined) {
+    return re.flags;
   }
-  return fs
+  // legacy browser support
+  return [
+    re.global ? "g" : "",
+    re.ignoreCase ? "i" : "",
+    re.multiline ? "m" : "",
+    re.unicode ? "u" : "",
+    re.sticky ? "y" : "",
+  ].join("");
 }
 
 function anchoredRegexp(re) {

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -703,7 +703,7 @@ function flags(re) {
     re.ignoreCase ? "i" : "",
     re.multiline ? "m" : "",
     re.unicode ? "u" : "",
-    re.sticky ? "y" : "",
+    re.sticky ? "y" : ""
   ].join("");
 }
 

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -1365,6 +1365,7 @@ Parsimmon.empty = empty;
 Parsimmon.end = end;
 Parsimmon.eof = eof;
 Parsimmon.fail = fail;
+Parsimmon.flags = flags;
 Parsimmon.formatError = formatError;
 Parsimmon.index = index;
 Parsimmon.isParser = isParser;

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -695,7 +695,12 @@ function formatError(input, error) {
 
 function flags(re) {
   var s = "" + re;
-  return s.slice(s.lastIndexOf("/") + 1);
+  var fs = s.slice(s.lastIndexOf("/") + 1);
+  if (fs === "undefined") {
+    // MS Edge v15-18 workaround
+    return ""
+  }
+  return fs
 }
 
 function anchoredRegexp(re) {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,5 +7,8 @@
     "Parsimmon": true,
     "assert": true,
     "testSetScenario": true
+  },
+  "rules": {
+    "no-invalid-regexp": ["error", {"allowConstructorFlags": ["u", "y"]}]
   }
 }

--- a/test/core/flags.test.js
+++ b/test/core/flags.test.js
@@ -1,0 +1,21 @@
+"use strict";
+
+testSetScenario(function() {
+  describe("Parsimmon.flags()", function() {
+    it("works in modern browsers", function() {
+      var flags = Parsimmon.flags(/a/gim);
+      assert.strictEqual(flags, "gim");
+    });
+
+    it("works on legacy browsers without Regexp.flags property", function() {
+      var oldRegExp = /a/gim;
+
+      // Simulate old RegExp without the flags property
+      Object.defineProperty(oldRegExp, "flags", { value: undefined });
+      assert.strictEqual(oldRegExp.flags, undefined);
+
+      var flags = Parsimmon.flags(oldRegExp);
+      assert.strictEqual(flags, "gim");
+    });
+  });
+});

--- a/test/core/flags.test.js
+++ b/test/core/flags.test.js
@@ -3,13 +3,11 @@
 testSetScenario(function() {
   describe("Parsimmon.flags()", function() {
     it("works in modern browsers", function() {
-      // eslint-disable-next-line no-invalid-regexp
       var flags = Parsimmon.flags(new RegExp("a", "gimuy"));
       assert.strictEqual(flags, "gimuy");
     });
 
     it("works on legacy browsers without Regexp.flags property with flags", function() {
-      // eslint-disable-next-line no-invalid-regexp
       var oldRegExp = new RegExp("a", "gimuy");
 
       // Simulate old RegExp without the flags property
@@ -21,7 +19,6 @@ testSetScenario(function() {
     });
 
     it("works on legacy browsers without Regexp.flags property without flags", function() {
-      // eslint-disable-next-line no-invalid-regexp
       var oldRegExp = new RegExp("a", "");
 
       // Simulate old RegExp without the flags property

--- a/test/core/flags.test.js
+++ b/test/core/flags.test.js
@@ -1,21 +1,60 @@
 "use strict";
 
 testSetScenario(function() {
-  describe("Parsimmon.flags()", function() {
+  describe("flags()", function() {
     it("works in modern browsers", function() {
-      var flags = Parsimmon.flags(new RegExp("a", "gimuy"));
-      assert.strictEqual(flags, "gimuy");
+      assert.throws(function() {
+        Parsimmon.regexp(new RegExp("a", "g"));
+      });
+      assert.doesNotThrow(function() {
+        Parsimmon.regexp(new RegExp("a", "i"));
+      });
+      assert.doesNotThrow(function() {
+        Parsimmon.regexp(new RegExp("a", "m"));
+      });
+      assert.doesNotThrow(function() {
+        Parsimmon.regexp(new RegExp("a", "u"));
+      });
+      assert.throws(function() {
+        Parsimmon.regexp(new RegExp("a", "y"));
+      });
     });
 
     it("works on legacy browsers without Regexp.flags property with flags", function() {
-      var oldRegExp = new RegExp("a", "gimuy");
+      var oldRegExpG = new RegExp("a", "g");
+      var oldRegExpI = new RegExp("a", "i");
+      var oldRegExpM = new RegExp("a", "m");
+      var oldRegExpU = new RegExp("a", "u");
+      var oldRegExpY = new RegExp("a", "y");
+      var oldRegExps = [
+        oldRegExpG,
+        oldRegExpI,
+        oldRegExpM,
+        oldRegExpU,
+        oldRegExpY
+      ];
 
       // Simulate old RegExp without the flags property
-      Object.defineProperty(oldRegExp, "flags", { value: undefined });
-      assert.strictEqual(oldRegExp.flags, undefined);
+      oldRegExps.map(function(r) {
+        Object.defineProperty(r, "flags", { value: undefined });
+        assert.strictEqual(r.flags, undefined);
+      });
 
-      var flags = Parsimmon.flags(oldRegExp);
-      assert.strictEqual(flags, "gimuy");
+      assert.throws(function() {
+        Parsimmon.regexp(oldRegExpG);
+      });
+      assert.doesNotThrow(function() {
+        Parsimmon.regexp(oldRegExpI);
+      });
+      assert.doesNotThrow(function() {
+        Parsimmon.regexp(oldRegExpM);
+      });
+      assert.doesNotThrow(function() {
+        Parsimmon.regexp(oldRegExpU);
+      });
+      assert.throws(function() {
+        Parsimmon.regexp(oldRegExpY);
+      });
     });
 
     it("works on legacy browsers without Regexp.flags property without flags", function() {
@@ -25,8 +64,9 @@ testSetScenario(function() {
       Object.defineProperty(oldRegExp, "flags", { value: undefined });
       assert.strictEqual(oldRegExp.flags, undefined);
 
-      var flags = Parsimmon.flags(oldRegExp);
-      assert.strictEqual(flags, "");
+      assert.doesNotThrow(function() {
+        Parsimmon.regexp(oldRegExp);
+      });
     });
   });
 });

--- a/test/core/flags.test.js
+++ b/test/core/flags.test.js
@@ -3,19 +3,33 @@
 testSetScenario(function() {
   describe("Parsimmon.flags()", function() {
     it("works in modern browsers", function() {
-      var flags = Parsimmon.flags(/a/gim);
-      assert.strictEqual(flags, "gim");
+      // eslint-disable-next-line no-invalid-regexp
+      var flags = Parsimmon.flags(new RegExp("a", "gimuy"));
+      assert.strictEqual(flags, "gimuy");
     });
 
-    it("works on legacy browsers without Regexp.flags property", function() {
-      var oldRegExp = /a/gim;
+    it("works on legacy browsers without Regexp.flags property with flags", function() {
+      // eslint-disable-next-line no-invalid-regexp
+      var oldRegExp = new RegExp("a", "gimuy");
 
       // Simulate old RegExp without the flags property
       Object.defineProperty(oldRegExp, "flags", { value: undefined });
       assert.strictEqual(oldRegExp.flags, undefined);
 
       var flags = Parsimmon.flags(oldRegExp);
-      assert.strictEqual(flags, "gim");
+      assert.strictEqual(flags, "gimuy");
+    });
+
+    it("works on legacy browsers without Regexp.flags property without flags", function() {
+      // eslint-disable-next-line no-invalid-regexp
+      var oldRegExp = new RegExp("a", "");
+
+      // Simulate old RegExp without the flags property
+      Object.defineProperty(oldRegExp, "flags", { value: undefined });
+      assert.strictEqual(oldRegExp.flags, undefined);
+
+      var flags = Parsimmon.flags(oldRegExp);
+      assert.strictEqual(flags, "");
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/jneen/parsimmon/issues/303

- [x] I have run `npm run lint:fix` to ensure Prettier and ESLint have passed
- [x] Coveralls bot has replied that the tests pass with 100% code coverage (`npm test`)
- [x] I have updated `CHANGELOG.md` (and `API.md` if this is an API ch

### Summary of problem

We saw these reports in our bug tracker:

```
Error unsupported regexp flag "n": /[0-9]/undefined 
    node_modules/parsimmon/build/parsimmon.umd.min.js:1:6716 Anonymous function
    node_modules/parsimmon/build/parsimmon.umd.min.js:1:6560 K
    node_modules/parsimmon/build/parsimmon.umd.min.js:1:11055 Anonymous function
    node_modules/parsimmon/build/parsimmon.umd.min.js:1:348 r
    node_modules/parsimmon/build/parsimmon.umd.min.js:1:407 Anonymous function
    node_modules/parsimmon/build/parsimmon.umd.min.js:1:199 Anonymous function
    node_modules/parsimmon/build/parsimmon.umd.min.js:1 Anonymous function
    webpack/bootstrap:25:3 __webpack_require__
    https://mywebsite.com/static/js/main.abc.js:1:123 Anonymous function
    webpack/bootstrap:25:3 __webpack_require__
```

These errors were coming from MS Edge versions 15-18, but I couldn't find a way to download and install that version to test for myself. It seemed like that browser was rendering the literal string `"undefined"` at the end of regular expressions when they were printed as strings.

### Research

To get some data from our prod environment, I added the following code to `parsimmon` (you can see the fork I used here: https://github.com/jneen/parsimmon/compare/master...ekilah:debuggingEdge18):

```js

function flags(re) {
  var s = "" + re;
  var fs = s.slice(s.lastIndexOf("/") + 1);
  if (fs === "undefined" || fs === undefined) {
    // eslint-disable-next-line no-console, no-undef
    console.warn('Flags of regex were undefined.', {re: re, s: s, fs: fs, typeofFs: typeof fs})
    return ""
  }
  return fs
}
```

and got this output from Edge versions 17 and 18:


```json
{
  "re":{},
  "s":"/[0-9]/undefined",
  "fs":"undefined",
  "typeofFs":"string"
}
```


I also added this above `var digit = regexp(/[0-9]/).desc("a digit");` so it would run when `parsimmon` is imported in my project:

```js
var reTest = new RegExp(/[0-9]/)
var reWithFlagTest = new RegExp(/[0-9]/i)
var strTest = new RegExp("[0-9]")

// eslint-disable-next-line no-console, no-undef
console.warn('Debugging regexes:', {
  re: {
    asString: '' + reTest,
    flagsDefined: typeof reTest.flags === 'string',
    flags: reTest.flags,
  },
  reWithFlag: {
    asString: '' + reWithFlagTest,
    flagsDefined: typeof reWithFlagTest.flags === 'string',
    flags: reWithFlagTest.flags,
  },
  str: {
    asString: '' + strTest,
    flagsDefined: typeof strTest.flags === 'string',
    flags: strTest.flags,
  },
})
```

and got this output from Edge versions 17 and 18:

```json
{
  "re":{
    "asString":"/[0-9]/undefined",
    "flagsDefined":false
  },
  "reWithFlag":{
    "asString":"/[0-9]/undefined",
    "flagsDefined":false
  },
  "str":{
    "asString":"/[0-9]/undefined",
    "flagsDefined":false
  }
}
```


### Fix

To fix this, we can detect `undefined` as the `flags` string and overwrite it.