### PR TITLE
docs: update link to performance benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,6 @@ Parsimmon is also compatible with [fantasyland][]. It implements Semigroup, Appl
 [promises-aplus]: https://promisesaplus.com/
 [parsec]: https://hackage.haskell.org/package/parsec
 [fantasyland]: https://github.com/fantasyland/fantasy-land
-[perf]: https://sap.github.io/chevrotain/performance/
+[perf]: https://chevrotain.io/performance/
 [es5]: https://kangax.github.io/compat-table/es5/
 [es5-shim]: https://github.com/es-shims/es5-shim


### PR DESCRIPTION
Chevrotain has moved to its own org and with its own DNS name: (chevrotain.io).
The old links may stop working in 1-2 months...
