### PR TITLE
fix: Improve the line/column number caching logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.0 (2021-04-16)
+
+- Improves the performance of line/column number tracking (contributed by @brendo-m)
+
 ## 1.16.0 (2020-08-25)
 
 - Fixes a crash in MS Edge 15-18 when using `Parsimmon.regexp` (thanks @ekilah)

--- a/test/core/index.test.js
+++ b/test/core/index.test.js
@@ -18,3 +18,28 @@ it("index", function() {
     column: 3
   });
 });
+
+it("multiple index", function() {
+  var parser = Parsimmon.seqMap(
+    Parsimmon.index,
+    Parsimmon.string("a\nb"),
+    Parsimmon.index,
+    function(i1, s, i2) {
+      return { index1: i1, str: s, index2: i2 };
+    }
+  );
+
+  assert.deepEqual(parser.parse("a\nb").value, {
+    index1: {
+      column: 1,
+      line: 1,
+      offset: 0
+    },
+    index2: {
+      column: 2,
+      line: 2,
+      offset: 3
+    },
+    str: "a\nb"
+  });
+});


### PR DESCRIPTION
- [x] I have run `npm run lint:fix` to ensure Prettier and ESLint have passed
- [x] Coveralls bot has replied that the tests pass with 100% code coverage (`npm test`)
- [x] I have updated `CHANGELOG.md` (and `API.md` if this is an API change)

I was running into performance issues when parsing very large files because of the O(n^2) nature of the `makeLineColumnIndex` method. https://github.com/jneen/parsimmon/pull/297 added some memoization but it didn't go far enough.

Instead of just returning the cached result if it exists we now walk backwards from the index until we find a previously cached index and compute the new line and column using that info. Hopefully the comments make it clear what's happening.

This version runs in O(n) and is a drastic improvement in efficiency. Parsing time for a 25k line file drops from ~90s to under 1s.