### PR TITLE
fix: Fix line number double counting bug when parsing optional newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.0 (2021-06-17)
+
+- Fixes a bug in the line/column number tracking when parsing optional newlines
+  
 ## 1.17.0 (2021-04-18)
 
 - Improves the performance of line/column number tracking (contributed by @brendo-m)

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -390,13 +390,6 @@ function makeLineColumnIndex(input, i) {
   var lineStart = 0;
   var j = i;
   while (j >= 0) {
-    if (input.charAt(j) === "\n") {
-      newLines++;
-      // lineStart === 0 when this is the first new line we have found
-      if (lineStart === 0) {
-        lineStart = j + 1;
-      }
-    }
     if (j in inputIndex) {
       prevLine = inputIndex[j].line;
       // lineStart === 0 when we haven't found a new line on the walk
@@ -406,6 +399,13 @@ function makeLineColumnIndex(input, i) {
         lineStart = inputIndex[j].lineStart;
       }
       break;
+    }
+    if (input.charAt(j) === "\n") {
+      newLines++;
+      // lineStart === 0 when this is the first new line we have found
+      if (lineStart === 0) {
+        lineStart = j + 1;
+      }
     }
     j--;
   }

--- a/test/core/mark.test.js
+++ b/test/core/mark.test.js
@@ -19,3 +19,24 @@ it("mark", function() {
     end: { offset: 3, line: 2, column: 3 }
   });
 });
+
+it("should correctly report line number when parsing optional newlines", function() {
+  var parser = Parsimmon.seq(
+    Parsimmon.newline,
+    Parsimmon.newline.many()
+  ).mark();
+
+  assert.deepEqual(parser.parse("\n").value, {
+    start: {
+      column: 0,
+      line: 2,
+      offset: 0
+    },
+    end: {
+      column: 1,
+      line: 2,
+      offset: 1
+    },
+    value: ["\n", []]
+  });
+});


### PR DESCRIPTION
Ran into a very subtle bug in my [previous PR](https://github.com/jneen/parsimmon/pull/321). Basically, when parsing a new line and then an optional newline there is a double count of the line number because of the order of the branches in the walking algorithm I wrote. Flipping the order fixes it.

I added a regression test, without this change you will see `line: 3` in `end`.

- [x] I have run `npm run lint:fix` to ensure Prettier and ESLint have passed
- [x] Coveralls bot has replied that the tests pass with 100% code coverage (`npm test`)
- [x] I have updated `CHANGELOG.md` (and `API.md` if this is an API change)
