### PR TITLE
Marks are confused when ^M is present in the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.1 (2021-10-27)
+
+- Fixes a further bug in the line/column number tracking dealing with ^M linebreaks
+
 ## 1.18.0 (2021-06-19)
 
 - Fixes a bug in the line/column number tracking when parsing optional newlines

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -401,29 +401,16 @@ function makeLineColumnIndex(input, i) {
       break;
     }
 
-    /**
-     * Defined as \r not followed by \n
-     */
-    var isCrAlone = function () {
-      return (input.charAt(j) === "\r" && input.charAt(j + 1) !== "\n");
-    }
-
-    /**
-     * Defined as \n not preceded by \r
-     */
-    var isLfAlone = function () {
-      return (input.charAt(j) === "\n" && input.charAt(j - 1) !== "\r");
-    }
-
-    /**
-     * Defined as \r followed by \n
-     */
-    var isCrLf = function () {
-      return (input.charAt(j) === "\r" && input.charAt(j + 1) === "\n");
-    }
-
     if (
-      isCrAlone() || isLfAlone() || isCrLf()
+      /**
+       * increment for every \n
+       */
+      (input.charAt(j) === "\n") ||
+      /**
+       * increment for every \r
+       * i.e. not followed by \n
+       */
+      (input.charAt(j) === "\r" && input.charAt(j + 1) !== "\n")
     ) {
       newLines++;
       // lineStart === 0 when this is the first new line we have found

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -400,7 +400,11 @@ function makeLineColumnIndex(input, i) {
       }
       break;
     }
-    if (input.charAt(j) === "\n") {
+
+    if (
+      input.charAt(j) === "\n" ||
+      (input.charAt(j) === "\r" && input.charAt(j + 1) !== "\n")
+    ) {
       newLines++;
       // lineStart === 0 when this is the first new line we have found
       if (lineStart === 0) {

--- a/src/parsimmon.js
+++ b/src/parsimmon.js
@@ -401,9 +401,29 @@ function makeLineColumnIndex(input, i) {
       break;
     }
 
+    /**
+     * Defined as \r not followed by \n
+     */
+    var isCrAlone = function () {
+      return (input.charAt(j) === "\r" && input.charAt(j + 1) !== "\n");
+    }
+
+    /**
+     * Defined as \n not preceded by \r
+     */
+    var isLfAlone = function () {
+      return (input.charAt(j) === "\n" && input.charAt(j - 1) !== "\r");
+    }
+
+    /**
+     * Defined as \r followed by \n
+     */
+    var isCrLf = function () {
+      return (input.charAt(j) === "\r" && input.charAt(j + 1) === "\n");
+    }
+
     if (
-      input.charAt(j) === "\n" ||
-      (input.charAt(j) === "\r" && input.charAt(j + 1) !== "\n")
+      isCrAlone() || isLfAlone() || isCrLf()
     ) {
       newLines++;
       // lineStart === 0 when this is the first new line we have found

--- a/test/core/mark.test.js
+++ b/test/core/mark.test.js
@@ -20,7 +20,7 @@ it("mark", function() {
   });
 });
 
-["\n", "\r"].forEach(function(eol) {
+["\n", "\r", "\r\n"].forEach(function(eol) {
   it(
     "should correctly report line number when parsing optional " +
       JSON.stringify(eol),
@@ -37,9 +37,9 @@ it("mark", function() {
           offset: 0
         },
         end: {
-          column: 1,
+          column: eol.length,
           line: 2,
-          offset: 1
+          offset: eol.length
         },
         value: [eol, []]
       });

--- a/test/core/mark.test.js
+++ b/test/core/mark.test.js
@@ -20,23 +20,29 @@ it("mark", function() {
   });
 });
 
-it("should correctly report line number when parsing optional newlines", function() {
-  var parser = Parsimmon.seq(
-    Parsimmon.newline,
-    Parsimmon.newline.many()
-  ).mark();
+["\n", "\r"].forEach(function(eol) {
+  it(
+    "should correctly report line number when parsing optional " +
+      JSON.stringify(eol),
+    function() {
+      var parser = Parsimmon.seq(
+        Parsimmon.newline,
+        Parsimmon.newline.many()
+      ).mark();
 
-  assert.deepEqual(parser.parse("\n").value, {
-    start: {
-      column: 0,
-      line: 2,
-      offset: 0
-    },
-    end: {
-      column: 1,
-      line: 2,
-      offset: 1
-    },
-    value: ["\n", []]
-  });
+      assert.deepEqual(parser.parse(eol).value, {
+        start: {
+          column: 0,
+          line: 2,
+          offset: 0
+        },
+        end: {
+          column: 1,
+          line: 2,
+          offset: 1
+        },
+        value: [eol, []]
+      });
+    }
+  );
 });

--- a/test/core/mark.test.js
+++ b/test/core/mark.test.js
@@ -26,22 +26,27 @@ it("mark", function() {
       JSON.stringify(eol),
     function() {
       var parser = Parsimmon.seq(
-        Parsimmon.newline,
-        Parsimmon.newline.many()
+        Parsimmon.string("foo"),
+        Parsimmon.newline
       ).mark();
 
-      assert.deepEqual(parser.parse(eol).value, {
+      var input = "foo" + eol
+
+      assert.deepEqual(parser.parse(input).value, {
         start: {
-          column: 0,
-          line: 2,
+          column: 1,
+          line: 1,
           offset: 0
         },
         end: {
-          column: eol.length,
+          column: 1,
           line: 2,
-          offset: eol.length
+          offset: input.length
         },
-        value: [eol, []]
+        value: [
+          "foo",
+          eol
+        ]
       });
     }
   );


### PR DESCRIPTION
Related to https://github.com/jneen/parsimmon/pull/324

^M line breaks are ancient now, they were seen on Mac OS 9 and earlier. Those files still exist and sometimes we'll have to parse them.

- [x] I have run `npm run lint:fix` to ensure Prettier and ESLint have passed
- [x] Coveralls bot has replied that the tests pass with 100% code coverage (`npm test`)
- [x] I have updated `CHANGELOG.md` (and `API.md` if this is an API change)
