### PR TITLE
Remove incorrect example from API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -911,7 +911,6 @@ var pNum = Parsimmon.regexp(/[0-9]+/)
 
 pNum.parse("9"); // => {status: true, value: 10}
 pNum.parse("123"); // => {status: true, value: 124}
-pNum.parse("3.1"); // => {status: true, value: 4.1}
 ```
 
 ## parser.contramap(fn)


### PR DESCRIPTION
Hey, thanks for an awesome lib!

I found a small mistake in docs: `pNum.parse('3.1')` returns a failure, so I think we might want to remove it.

Executable example: https://stackblitz.com/edit/node-dthvmq
